### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
           - os: windows-latest
             python-version: '3.10'
           # Other Python versions
-          #- os: ubuntu-latest
-          #  python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.9'
           # Other pandas versions
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering',
 ]


### PR DESCRIPTION
Adds Python 3.9 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.9 and enable corresponding tests in the CI workflow.

New Features:
- Add support for Python 3.9 in the Python package.

CI:
- Enable tests for Python 3.9 on Ubuntu runners in the CI workflow.