### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
           # Other Python versions
           - os: ubuntu-latest
             python-version: '3.9'
-          # Other pandas versions
+          - os: ubuntu-latest
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'


### PR DESCRIPTION
Adds Python 3.11 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.11 and update CI to test this version on Ubuntu runners.

New Features:
- Add support for Python 3.11 in the project.

CI:
- Enable testing for Python 3.11 on Ubuntu runners in the CI workflow.