### PR TITLE
Add audmodle-internal S3 repo to defaults

### DIFF
--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -13,5 +13,10 @@ class config:
             "https://artifactory.audeering.com/artifactory",
             "artifactory",
         ),
+        Repository(
+            "audmodel-internal",
+            "s3.dualstack.eu-north-1.amazonaws.com",
+            "s3",
+        ),
     ]
     r"""Default repositories (will be searched in given order)."""

--- a/audmodel/core/repository.py
+++ b/audmodel/core/repository.py
@@ -85,12 +85,8 @@ class Repository:
     def create_backend_interface(self) -> type[audbackend.interface.Base]:
         r"""Create backend interface to access repository.
 
-        It wraps an :class:`audbackend.interface.Versioned` interface
-        around it.
-
-        When :attr:`Repository.backend` equals ``artifactory``,
-        it wraps an :class:`audbackend.interface.Maven` interface
-        around it.
+        It wraps an :class:`audbackend.interface.Maven` interface
+        around the backend.
 
         The returned backend instance
         has not yet established a connection to the backend.
@@ -116,15 +112,13 @@ class Repository:
             raise ValueError(f"'{self.backend}' is not a registered backend")
         backend_class = self.backend_registry[self.backend]
         backend = backend_class(self.host, self.name)
-        if self.backend == "artifactory":
-            return audbackend.interface.Maven(  # pragma: no cover
-                backend,
-                extensions=[
-                    define.HEADER_EXT,
-                    define.META_EXT,
-                ],
-            )
-        return audbackend.interface.Versioned(backend)
+        return audbackend.interface.Maven(
+            backend,
+            extensions=[
+                define.HEADER_EXT,
+                define.META_EXT,
+            ],
+        )
 
     @classmethod
     def register(

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,7 +1,12 @@
 Authentication
 ==============
 
-Users have to store their credentials in :file:`~/.artifactory_python.cfg`:
+To download or publish a model,
+a user has to authenticate.
+
+Credentials for the ``models-local`` repository
+on Artifactory
+are stored in ``~/.artifactory_python.cfg``:
 
 .. code-block:: cfg
 
@@ -9,9 +14,28 @@ Users have to store their credentials in :file:`~/.artifactory_python.cfg`:
     username = MY_USERNAME
     password = MY_API_KEY
 
-Alternatively, they can export them as environment variables:
+Alternatively,
+they can export them as environment variables:
 
 .. code-block:: bash
 
     export ARTIFACTORY_USERNAME="MY_USERNAME"
     export ARTIFACTORY_API_KEY="MY_API_KEY"
+
+Credentials for the ``audmodel-internal`` repository
+on S3
+are stored in ``~/.config/audbackend/minio.cfg``:
+
+.. code-block:: cfg
+
+    [s3.dualstack.eu-north-1.amazonaws.com]
+    access_key = MY_ACCESS_KEY
+    secret_key = MY_SECRET_KEY
+
+Alternatively,
+users can export them as environment variables:
+
+.. code-block:: bash
+
+    export MINIO_ACCESS_KEY="MY_ACCESS_KEY"
+    export MINIO_SECRET_KEY="MY_SECRET_KEY"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -120,12 +120,10 @@ Let's define the arguments for our example model:
     }
     subgroup = "emotion.cnn"
 
-Per default :mod:`audmodel` uses a repository
-on our internal Artifactory server,
-and you don't have to care about it.
+Per default :mod:`audmodel` uses repositories
+on Artifactory and S3.
 For this example
-we don't want to interfere with Artifactory
-and create a local temporary repository
+we create a local temporary repository
 in which the model is stored.
 
 .. jupyter-execute::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[artifactory] >=2.0.0',
+    'audbackend[all] >=2.2.1',
     'oyaml',
 ]
 # Get version dynamically from git

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -113,3 +113,38 @@ def test_repository_create_backend_interface(
     assert isinstance(backend_interface, expected_interface)
     assert isinstance(backend_interface.backend, expected_backend)
     assert not backend_interface.backend.opened
+
+
+@pytest.mark.parametrize(
+    "backend, host, repo, expected_error_msg, expected_error",
+    [
+        (
+            "custom",
+            "host",
+            "repo",
+            "'custom' is not a registered backend",
+            ValueError,
+        ),
+        pytest.param(
+            "artifactory",
+            "host",
+            "repo",
+            "The 'artifactory' backend is not supported in Python>=3.12",
+            ValueError,
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 12),
+                reason="Should only fail for Python>=3.12",
+            ),
+        ),
+    ],
+)
+def test_repository_create_backend_interface_errors(
+    backend,
+    host,
+    repo,
+    expected_error_msg,
+    expected_error,
+):
+    repository = audmodel.Repository(repo, host, backend)
+    with pytest.raises(expected_error, match=expected_error_msg):
+        repository.create_backend_interface()


### PR DESCRIPTION
Add `audmodle-internal` repository on S3 to the default repositories as configured in `audmodel.config.REPOSITORIES`.

It also updates the documentation on authentication accordingly (at the moment, we don't have a public repository):

![image](https://github.com/user-attachments/assets/a390b6f4-7ded-4489-8b13-a01f436f8879)

It also updates the `Repository` to support S3 and MinIO, but different to `audb` we always use the `Maven` interface for versioning, to provide a better structure for the `_uid` folder, which we use a lookup for model IDs.

![image](https://github.com/user-attachments/assets/1b62ef42-2900-49c8-91fd-103840730465)


## Summary by Sourcery

Add the 'audmodel-internal' S3 repository to the default configuration and update the documentation to reflect changes in authentication requirements.

New Features:
- Add 'audmodel-internal' S3 repository to the default repositories list in the configuration.

Documentation:
- Update documentation to include information on authentication for the new 'audmodel-internal' S3 repository.