### PR TITLE
DOC: simplify subgroup example in publish()

### DIFF
--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -454,7 +454,7 @@ def publish(
     |              |    the model        |                                      |
     +--------------+---------------------+--------------------------------------+
     | ``subgroup`` | - project           | - ser.dimensions.wav2vec2            |
-    |              | - task the model    | - projectsmile.sex.cnn               |
+    |              | - task the model    | - age.cnn                            |
     |              |   was trained for   |                                      |
     |              | - model architecture|                                      |
     +--------------+---------------------+--------------------------------------+
@@ -502,14 +502,10 @@ def publish(
         date: date, defaults to current timestamp
         meta: dictionary with meta information
         repository: repository where the model will be published
-        subgroup: extend group ID to
-            ``com.audeering.models.<subgroup>``.
-            You can increase the depth
-            by using dot-notation,
-            e.g. setting
-            ``subgroup=foo.bar``
-            will result in
-            ``com.audeering.models.foo.bar``
+        subgroup: subgroup under which
+            the model is stored on backend.
+            ``.`` are replaced by ``/``
+            on the backend
         verbose: show debug messages
 
     Returns:


### PR DESCRIPTION
This simplifies the discussion on how to use he `subgroup` argument of `audmodel.publish()`.

![image](https://github.com/user-attachments/assets/a4fd142f-ad91-4326-a7a0-fb12c8f89339)

## Summary by Sourcery

Documentation:
- Simplify the explanation of the 'subgroup' argument in the 'publish' function documentation.