### PR TITLE
TST: ensure code coverage is uploaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .idea/
 venv/
 .coverage
+coverage.xml
 docs/pics/*.svg
 docs/.ipynb_checkpoints
 docs/api/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ addopts = '''
     --doctest-plus
     --cov=audmodel
     --cov-fail-under=100
-    --cov-report term-missing
+    --cov-report xml
     --ignore=docs/
     --ignore=misc/
 '''


### PR DESCRIPTION
Switches code coverage file to XML, in order to upload it to codecov.

## Summary by Sourcery

CI:
- Switch code coverage report format from term-missing to XML to enable upload to Codecov.