### PR TITLE
Support Artifactory backend under Python 3.12

### DIFF
--- a/audmodel/core/repository.py
+++ b/audmodel/core/repository.py
@@ -44,7 +44,7 @@ class Repository:
     Holds mapping between registered backend names,
     and their corresponding backend classes.
     The ``"artifactory"`` backend is currently not available
-    under Python >=3.12.
+    under Python >=3.13.
 
     """
 
@@ -100,13 +100,13 @@ class Repository:
             interface to repository
 
         Raises:
-            ValueError: if an artifactory backend is requested in Python>=3.12
+            ValueError: if an artifactory backend is requested in Python>=3.13
             ValueError: if a non-supported backend is requested
 
         """
-        if sys.version_info >= (3, 12) and self.backend == "artifactory":
+        if sys.version_info >= (3, 13) and self.backend == "artifactory":
             raise ValueError(  # pragma: no cover
-                "The 'artifactory' backend is not supported in Python>=3.12"
+                "The 'artifactory' backend is not supported in Python>=3.13"
             )
         if self.backend not in self.backend_registry:
             raise ValueError(f"'{self.backend}' is not a registered backend")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[all] >=2.2.1',
+    'audbackend[all] >=2.2.2',
     'oyaml',
 ]
 # Get version dynamically from git

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -86,7 +86,7 @@ def test_repository_repr(backend, host, repo, expected):
             audbackend.interface.Maven,
             marks=pytest.mark.skipif(
                 sys.version_info >= (3, 13),
-                reason="No artifactory backend support in Python>=3.12",
+                reason="No artifactory backend support in Python>=3.13",
             ),
         ),
     ],

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -85,7 +85,7 @@ def test_repository_repr(backend, host, repo, expected):
             artifactory_backend,
             audbackend.interface.Maven,
             marks=pytest.mark.skipif(
-                sys.version_info >= (3, 12),
+                sys.version_info >= (3, 13),
                 reason="No artifactory backend support in Python>=3.12",
             ),
         ),
@@ -129,11 +129,11 @@ def test_repository_create_backend_interface(
             "artifactory",
             "host",
             "repo",
-            "The 'artifactory' backend is not supported in Python>=3.12",
+            "The 'artifactory' backend is not supported in Python>=3.13",
             ValueError,
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 12),
-                reason="Should only fail for Python>=3.12",
+                sys.version_info < (3, 13),
+                reason="Should only fail for Python>=3.13",
             ),
         ),
     ],


### PR DESCRIPTION
Adds support for the Artifactory backend under Python 3.12, making use of the same feature introduced in `audbackend==2.2.2`.

## Summary by Sourcery

Update the audmodel package to support Python 3.12 with Artifactory backend, by bumping the audbackend dependency to a version that includes the fix.