### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
             python-version: '3.10'
           # Other Python versions
           - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] >=2.2.2',
     'oyaml',


### PR DESCRIPTION
Remove support for Python 3.9 as it reached its end-of-life.

## Summary by Sourcery

Remove support for Python 3.9 by updating project metadata and CI configurations.

Build:
- Update minimum Python requirement to >=3.10 and remove Python 3.9 classifier in pyproject.toml

CI:
- Remove Python 3.9 test job from GitHub Actions workflow