### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
             python-version: '3.12'
           - os: ubuntu-latest
             python-version: '3.13'
+          - os: ubuntu-latest
+            python-version: '3.14'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.10'


### PR DESCRIPTION
Adds support and tests for Python 3.14.

## Summary by Sourcery

Add support for Python 3.14 by updating the CI test matrix and package metadata.

New Features:
- Support Python 3.14

Enhancements:
- Add Python 3.14 classifier in pyproject.toml

CI:
- Include Python 3.14 in the GitHub Actions test matrix