### PR TITLE
Lock cache when loading models

### DIFF
--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -273,7 +273,7 @@ def load(
     uid: str,
     *,
     cache_root: str | None = None,
-    timeout: float = 86400,  # 24 h
+    timeout: float = 14400,  # 4 h
     verbose: bool = False,
 ) -> str:
     r"""Download a model by its unique ID.

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -273,6 +273,7 @@ def load(
     uid: str,
     *,
     cache_root: str | None = None,
+    timeout: float = 86400,  # 24 h
     verbose: bool = False,
 ) -> str:
     r"""Download a model by its unique ID.
@@ -287,6 +288,8 @@ def load(
         uid: unique model ID or short ID for latest version
         cache_root: cache folder where models and headers are stored.
             If not set :meth:`audmodel.default_cache_root` is used
+        timeout: maximum time in seconds
+            before giving up acquiring a lock
         verbose: show debug messages
 
     Returns:
@@ -306,7 +309,7 @@ def load(
     """
     cache_root = audeer.safe_path(cache_root or default_cache_root())
     short_id, version = split_uid(uid, cache_root)
-    return get_archive(short_id, version, cache_root, verbose)
+    return get_archive(short_id, version, cache_root, verbose, timeout)
 
 
 def meta(

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -309,7 +309,7 @@ def load(
     """
     cache_root = audeer.safe_path(cache_root or default_cache_root())
     short_id, version = split_uid(uid, cache_root)
-    return get_archive(short_id, version, cache_root, verbose, timeout)
+    return get_archive(short_id, version, cache_root, timeout, verbose)
 
 
 def meta(

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -45,6 +45,7 @@ def author(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> author("d4e9c65b-3.0.0")
@@ -73,6 +74,7 @@ def date(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> date("d4e9c65b-3.0.0")
@@ -158,6 +160,7 @@ def header(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist on backend
+        filelock.Timeout: if cache lock could not be acquired
 
     Returns:
         dictionary with header fields
@@ -293,6 +296,7 @@ def load(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> root = load("d4e9c65b-3.0.0")
@@ -326,6 +330,7 @@ def meta(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> d = meta("d4e9c65b-3.0.0")
@@ -372,6 +377,7 @@ def name(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> name("d4e9c65b-3.0.0")
@@ -402,6 +408,7 @@ def parameters(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> parameters("d4e9c65b-3.0.0")
@@ -673,6 +680,7 @@ def subgroup(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> subgroup("d4e9c65b-3.0.0")
@@ -941,6 +949,7 @@ def version(
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if model does not exist
+        filelock.Timeout: if cache lock could not be acquired
 
     Examples:
         >>> version("d4e9c65b-3.0.0")

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -60,6 +60,7 @@ def get_archive(
     version: str,
     cache_root: str,
     verbose: bool,
+    timeout: float = 10,
 ) -> str:
     r"""Return backend and local archive path.
 
@@ -67,6 +68,8 @@ def get_archive(
         short_id: model ID without version
         version: model version
         cache_root: path of cache root
+        timeout: maximum time in seconds
+            before giving up acquiring a lock
         verbose: if ``True`` show message
             or progress bar
             when downloading file
@@ -85,7 +88,7 @@ def get_archive(
         version,
     )
 
-    with lock(root):
+    with lock(root, timeout=timeout):
         if not os.path.exists(root) or len(os.listdir(root)) == 0:
             tmp_root = audeer.mkdir(f"{root}~")
             backend_interface, path = archive_path(

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -59,8 +59,8 @@ def get_archive(
     short_id: str,
     version: str,
     cache_root: str,
+    timeout: float,
     verbose: bool,
-    timeout: float = 10,
 ) -> str:
     r"""Return backend and local archive path.
 

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -10,7 +10,7 @@ import audeer
 
 from audmodel.core.config import config
 import audmodel.core.define as define
-from audmodel.core.lock import Lock
+from audmodel.core.lock import lock
 import audmodel.core.utils as utils
 
 
@@ -85,7 +85,7 @@ def get_archive(
         version,
     )
 
-    with Lock(root):
+    with lock(root):
         if not os.path.exists(root) or len(os.listdir(root)) == 0:
             tmp_root = audeer.mkdir(root + "~")
             backend_interface, path = archive_path(
@@ -154,7 +154,7 @@ def get_header(
         f"{version}.{define.HEADER_EXT}",
     )
 
-    with Lock(local_path):
+    with lock(local_path):
         # header is not in cache download it
         if not os.path.exists(local_path):
             with backend_interface.backend:
@@ -213,7 +213,7 @@ def get_meta(
         f"{version}.{define.META_EXT}",
     )
 
-    with Lock(local_path):
+    with lock(local_path):
         with backend_interface.backend:
             # if metadata in cache,
             # figure out if it matches remote version

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -87,7 +87,7 @@ def get_archive(
 
     with lock(root):
         if not os.path.exists(root) or len(os.listdir(root)) == 0:
-            tmp_root = audeer.mkdir(root + "~")
+            tmp_root = audeer.mkdir(f"{root}~")
             backend_interface, path = archive_path(
                 short_id,
                 version,

--- a/audmodel/core/define.py
+++ b/audmodel/core/define.py
@@ -12,3 +12,6 @@ r"""Private repository for legacy models."""
 
 LEGACY_REPOSITORY_PUBLIC = "models-public-local"
 r"""Public repository for legacy models."""
+
+LOCK_FILE = ".lock"
+r"""Name of lock file in cache."""

--- a/audmodel/core/define.py
+++ b/audmodel/core/define.py
@@ -12,6 +12,3 @@ r"""Private repository for legacy models."""
 
 LEGACY_REPOSITORY_PUBLIC = "models-public-local"
 r"""Public repository for legacy models."""
-
-LOCK_FILE = ".lock"
-r"""Name of lock file in cache."""

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -65,7 +65,7 @@ class Lock:
                     lock.acquire(timeout=remaining_time)
                 except filelock.Timeout:
                     warnings.warn(
-                        "Lock could not be acquired. Timeout exceeded.",
+                        f"The file lock '{lock_file}' could not be acquired.",
                         category=UserWarning,
                     )
 

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -13,7 +13,7 @@ import audeer
 def lock(
     paths: list[str],
     *,
-    timeout: float = 86400,
+    timeout: float = 10,
     warning_timeout: float = 0,
 ):
     """Create lock for given paths.

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -26,7 +26,7 @@ def lock(
             an exception is raised
         warn: if ``True``
             a warning is shown to the user
-            that the lock could not yet get acquired
+            if the lock cannot be acquired
     Raises:
         :class:`filelock.Timeout`: if a timeout is reached
 

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -1,112 +1,59 @@
-from collections.abc import Sequence
+from contextlib import ExitStack
+from contextlib import contextmanager
 import os
-import types
 import warnings
 
-import filelock
+from filelock import FileLock
+from filelock import Timeout
 
 import audeer
 
 
-class Lock:
-    def __init__(
-        self,
-        paths: str | Sequence[str],
-        *,
-        timeout: float = 86400,  # 24 h
-        warning_timeout: float = 2,
-    ):
-        r"""Lock one or more files or folders.
-
-        Waits until all locks can be acquired.
-        While locked a path `a/b/c` is locked
-        a file `a/b/.c.lock` will be created.
-
-        Args:
-            paths: path to one or more files or folders that should be locked
-            timeout: maximum time in seconds
-                before giving up acquiring a lock to the cache folder.
-                If timeout is reached,
-                an exception is raised
-            warning_timeout: time in seconds
-                after which a warning is shown to the user
-                that the lock could not yet get acquired
-
-        Raises:
-            :class:`filelock.Timeout`: if a timeout is reached
-
-        """
-        self.lock_files = self._lock_files(paths)
-        self.locks = [filelock.FileLock(file) for file in self.lock_files]
-        self.timeout = timeout
-        self.warning_timeout = warning_timeout
-
-    def __enter__(self) -> "Lock":
-        r"""Acquire the lock(s)."""
-        for lock, lock_file in zip(self.locks, self.lock_files):
-            remaining_time = self.timeout
+@contextmanager
+def lock(paths, *, timeout=86400, warning_timeout=2):
+    # reuse your existing function
+    lock_files = _lock_files(paths)
+    locks = [FileLock(f, timeout=timeout) for f in lock_files]
+    with ExitStack() as stack:
+        for lock, f in zip(locks, lock_files):
+            remaining_time = timeout
             acquired = False
-            # First try to acquire lock in warning_timeout time
-            if self.warning_timeout < self.timeout:
+            if warning_timeout < timeout:
                 try:
-                    lock.acquire(timeout=self.warning_timeout)
+                    lock.acquire(timeout=warning_timeout)
                     acquired = True
-                except filelock.Timeout:
+                except Timeout:
+                    remaining_time = timeout - warning_timeout
                     warnings.warn(
-                        f"Lock could not be acquired immediately.\n"
-                        "Another user might loading the same model.\n"
-                        f"Still trying for {self.timeout - self.warning_timeout:.1f} "
-                        "more seconds...\n"
+                        f"Lock '{f}' delayed; retrying for {remaining_time}s."
                     )
-                    remaining_time = self.timeout - self.warning_timeout
-
             if not acquired:
-                try:
-                    lock.acquire(timeout=remaining_time)
-                except filelock.Timeout:
-                    warnings.warn(
-                        f"The file lock '{lock_file}' could not be acquired.",
-                        category=UserWarning,
-                    )
+                lock.acquire(timeout=remaining_time)
+            stack.enter_context(lock)
+        yield
 
-        return self
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: types.TracebackType | None,
-    ) -> None:
-        """Release the lock(s)."""
-        for lock in self.locks:
-            lock.release()
+def _lock_files(paths: list[str]) -> list[str]:
+    """Create lock files if not existent.
 
-    def __del__(self) -> None:
-        """Called when the lock object is deleted."""
-        for lock in self.locks:
-            lock.release(force=True)
+    The lock files are created outside the folder,
+    to allow to delete/overwrite the folder
+    by the process.
 
-    def _lock_files(self, paths: list[str]) -> list[str]:
-        """Create lock files if not existent.
+    Args:
+        paths: files or folders that should be locked
 
-        The lock files are created outside the folder,
-        to allow to delete/overwrite the folder
-        by the process.
+    Returns:
+        path to lock files
 
-        Args:
-            paths: files or folders that should be locked
-
-        Returns:
-            path to lock files
-
-        """
-        lock_files = []
-        paths = [audeer.path(path) for path in audeer.to_list(paths)]
-        for path in paths:
-            dirname = audeer.mkdir(os.path.dirname(path))
-            basename = os.path.basename(path)
-            lock_file = audeer.path(dirname, f".{basename}.lock")
-            if not os.path.exists(lock_file):
-                audeer.touch(lock_file)
-            lock_files.append(lock_file)
-        return lock_files
+    """
+    lock_files = []
+    paths = [audeer.path(path) for path in sorted(audeer.to_list(paths))]
+    for path in paths:
+        dirname = audeer.mkdir(os.path.dirname(path))
+        basename = os.path.basename(path)
+        lock_file = audeer.path(dirname, f".{basename}.lock")
+        if not os.path.exists(lock_file):
+            audeer.touch(lock_file)
+        lock_files.append(lock_file)
+    return lock_files

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -14,7 +14,7 @@ def lock(
     paths: list[str],
     *,
     timeout: float = 86400,
-    warning_timeout: float = 2,
+    warning_timeout: float = 0,
 ):
     """Create lock for given paths.
 

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -41,7 +41,9 @@ def lock(
                     lock.acquire(timeout=0)
                     acquired = True
                 except Timeout:
-                    warnings.warn(f"Lock '{f}' delayed; retrying for {timeout}s.")
+                    warnings.warn(
+                        f"Could not acquire lock '{f}'; retrying for {timeout}s."
+                    )
             if not acquired:
                 lock.acquire(timeout=timeout)
             stack.enter_context(lock)

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -1,0 +1,112 @@
+from collections.abc import Sequence
+import os
+import types
+import warnings
+
+import filelock
+
+import audeer
+
+
+class Lock:
+    def __init__(
+        self,
+        paths: str | Sequence[str],
+        *,
+        timeout: float = 86400,  # 24 h
+        warning_timeout: float = 2,
+    ):
+        r"""Lock one or more files or folders.
+
+        Waits until all locks can be acquired.
+        While locked a path `a/b/c` is locked
+        a file `a/b/.c.lock` will be created.
+
+        Args:
+            paths: path to one or more files or folders that should be locked
+            timeout: maximum time in seconds
+                before giving up acquiring a lock to the cache folder.
+                If timeout is reached,
+                an exception is raised
+            warning_timeout: time in seconds
+                after which a warning is shown to the user
+                that the lock could not yet get acquired
+
+        Raises:
+            :class:`filelock.Timeout`: if a timeout is reached
+
+        """
+        self.lock_files = self._lock_files(paths)
+        self.locks = [filelock.FileLock(file) for file in self.lock_files]
+        self.timeout = timeout
+        self.warning_timeout = warning_timeout
+
+    def __enter__(self) -> "Lock":
+        r"""Acquire the lock(s)."""
+        for lock, lock_file in zip(self.locks, self.lock_files):
+            remaining_time = self.timeout
+            acquired = False
+            # First try to acquire lock in warning_timeout time
+            if self.warning_timeout < self.timeout:
+                try:
+                    lock.acquire(timeout=self.warning_timeout)
+                    acquired = True
+                except filelock.Timeout:
+                    warnings.warn(
+                        f"Lock could not be acquired immediately.\n"
+                        "Another user might loading the same model.\n"
+                        f"Still trying for {self.timeout - self.warning_timeout:.1f} "
+                        "more seconds...\n"
+                    )
+                    remaining_time = self.timeout - self.warning_timeout
+
+            if not acquired:
+                try:
+                    lock.acquire(timeout=remaining_time)
+                except filelock.Timeout:
+                    warnings.warn(
+                        "Lock could not be acquired. Timeout exceeded.",
+                        category=UserWarning,
+                    )
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> None:
+        """Release the lock(s)."""
+        for lock in self.locks:
+            lock.release()
+
+    def __del__(self) -> None:
+        """Called when the lock object is deleted."""
+        for lock in self.locks:
+            lock.release(force=True)
+
+    def _lock_files(self, paths: list[str]) -> list[str]:
+        """Create lock files if not existent.
+
+        The lock files are created outside the folder,
+        to allow to delete/overwrite the folder
+        by the process.
+
+        Args:
+            paths: files or folders that should be locked
+
+        Returns:
+            path to lock files
+
+        """
+        lock_files = []
+        paths = [audeer.path(path) for path in audeer.to_list(paths)]
+        for path in paths:
+            dirname = audeer.mkdir(os.path.dirname(path))
+            basename = os.path.basename(path)
+            lock_file = audeer.path(dirname, f".{basename}.lock")
+            if not os.path.exists(lock_file):
+                audeer.touch(lock_file)
+            lock_files.append(lock_file)
+        return lock_files

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -10,8 +10,27 @@ import audeer
 
 
 @contextmanager
-def lock(paths, *, timeout=86400, warning_timeout=2):
-    # reuse your existing function
+def lock(
+    paths: list[str],
+    *,
+    timeout: float = 86400,
+    warning_timeout: float = 2,
+):
+    """Create lock for given paths.
+
+    Args:
+        paths: files or folders to acquire lock
+        timeout: maximum time in seconds
+            before giving up acquiring a lock.
+            If timeout is reached,
+            an exception is raised
+        warning_timeout: time in seconds
+            after which a warning is shown to the user
+            that the lock could not yet get acquired
+    Raises:
+        :class:`filelock.Timeout`: if a timeout is reached
+
+    """
     lock_files = _lock_files(paths)
     locks = [FileLock(f, timeout=timeout) for f in lock_files]
     with ExitStack() as stack:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "audbackend": ("https://audeering.github.io/audbackend/", None),
     "audfactory": ("https://audeering.github.io/audfactory/", None),
+    "filelock": ("https://py-filelock.readthedocs.io/en/latest/", None),
 }
 # Disable Gitlab as we need to sign in
 linkcheck_ignore = [

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -339,7 +339,7 @@ in ``audb``'s documentation.
 ``audmodel`` uses lock files to avoid race conditions
 when trying to access the same file.
 You can only use a shared cache on the same platform
-as the file lock mechanism is not cross platform compatible.
+as the file lock mechanism is not cross-platform compatible.
 
 
 .. jupyter-execute::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -328,6 +328,20 @@ the model is placed in a unique sub-folder, namely
 ``<uid>/<version>``.
 
 
+Shared cache folder
+-------------------
+
+You can use a shared cache folder.
+Ensure to set the correct access rights,
+compare the
+`shared cache section <https://audeering.github.io/audb/caching.html#shared-cache>`_
+in ``audb``'s documentation.
+``audmodel`` uses lock files to avoid race conditions
+when trying to access the same file.
+You can only use a shared cache on the same platform
+as the file lock mechanism is not cross platform compatible.
+
+
 .. jupyter-execute::
     :hide-code:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] >=2.2.2',
+    'filelock',
     'oyaml',
 ]
 # Get version dynamically from git

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -153,7 +153,7 @@ def test_lock_warning_and_failure(tmpdir):
     lock_file = audeer.touch(tmpdir, ".file.txt.lock")
     lock_error = filelock.Timeout
     lock_error_msg = f"The file lock '{lock_file}' could not be acquired."
-    warning_msg = f"Lock '{lock_file}' delayed; retrying for 0.2s."
+    warning_msg = f"Could not acquire lock '{lock_file}'; retrying for 0.2s."
     # Acquire first lock to force failing second lock
     with lock(path):
         with pytest.warns(UserWarning, match=re.escape(warning_msg)):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -27,14 +27,17 @@ def job(lock, wait, sleep):
 
 
 def test_lock(tmpdir):
+    # avoid displaying a warning
+    warning_timeout = 2
+
     # create two lock folders
 
     lock_folders = [audeer.mkdir(tmpdir, str(idx)) for idx in range(2)]
 
     # lock 1 and 2
 
-    lock_1 = lock(lock_folders[0])
-    lock_2 = lock(lock_folders[1])
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
+    lock_2 = lock(lock_folders[1], warning_timeout=warning_timeout)
 
     event.clear()
     result = audeer.run_tasks(
@@ -49,9 +52,9 @@ def test_lock(tmpdir):
 
     # lock 1, 2 and 1+2
 
-    lock_1 = lock(lock_folders[0])
-    lock_2 = lock(lock_folders[1])
-    lock_12 = lock(lock_folders)
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
+    lock_2 = lock(lock_folders[1], warning_timeout=warning_timeout)
+    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
 
     result = audeer.run_tasks(
         job,
@@ -66,8 +69,8 @@ def test_lock(tmpdir):
 
     # lock 1, then 1+2 + wait
 
-    lock_1 = lock(lock_folders[0])
-    lock_12 = lock(lock_folders)
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
+    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
 
     event.clear()
     result = audeer.run_tasks(
@@ -82,8 +85,8 @@ def test_lock(tmpdir):
 
     # lock 1, then 1+2 + timeout
 
-    lock_1 = lock(lock_folders[0])
-    lock_12 = lock(lock_folders, timeout=0)
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
+    lock_12 = lock(lock_folders, warning_timeout=warning_timeout, timeout=0)
 
     event.clear()
     result = audeer.run_tasks(
@@ -98,8 +101,8 @@ def test_lock(tmpdir):
 
     # lock 1+2, then 1 + wait
 
-    lock_1 = lock(lock_folders[0])
-    lock_12 = lock(lock_folders)
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
+    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
 
     event.clear()
     result = audeer.run_tasks(
@@ -114,8 +117,8 @@ def test_lock(tmpdir):
 
     # lock 1+2, then 1 + timeout
 
-    lock_1 = lock(lock_folders[0], timeout=0)
-    lock_12 = lock(lock_folders)
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout, timeout=0)
+    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
 
     event.clear()
     result = audeer.run_tasks(
@@ -130,8 +133,8 @@ def test_lock(tmpdir):
 
     # lock 1+2, then 1 + wait and 2 + timeout
 
-    lock_1 = lock(lock_folders[0])
-    lock_2 = lock(lock_folders[1], timeout=0)
+    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
+    lock_2 = lock(lock_folders[1], warning_timeout=warning_timeout, timeout=0)
     lock_12 = lock(lock_folders)
 
     event.clear()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -144,7 +144,7 @@ def test_lock(tmpdir):
         ],
         num_workers=3,
     )
-    assert set(result) == set([1, 0, 1])
+    assert set(result) == {0, 1}
 
 
 def test_lock_warning_and_failure(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,164 @@
+import re
+import threading
+import time
+
+import filelock
+import pytest
+
+import audeer
+
+from audmodel.core.lock import Lock
+
+
+event = threading.Event()
+
+
+def job(lock, wait, sleep):
+    if wait:
+        event.wait()  # wait for another thread to enter the lock
+    with lock:
+        if not wait:
+            event.set()  # notify waiting threads to enter the lock
+        time.sleep(sleep)
+        # Finished without timeout
+        return 1
+    return 0
+
+
+def test_lock(tmpdir):
+    # create two lock folders
+
+    lock_folders = [audeer.mkdir(tmpdir, str(idx)) for idx in range(2)]
+
+    # lock 1 and 2
+
+    lock_1 = Lock(lock_folders[0])
+    lock_2 = Lock(lock_folders[1])
+
+    event.clear()
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, False, 0], {}),
+            ([lock_2, False, 0], {}),
+        ],
+        num_workers=2,
+    )
+    assert result == [1, 1]
+
+    # lock 1, 2 and 1+2
+
+    lock_1 = Lock(lock_folders[0])
+    lock_2 = Lock(lock_folders[1])
+    lock_12 = Lock(lock_folders)
+
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, False, 0], {}),
+            ([lock_2, False, 0], {}),
+            ([lock_12, False, 0], {}),
+        ],
+        num_workers=3,
+    )
+    assert result == [1, 1, 1]
+
+    # lock 1, then 1+2 + wait
+
+    lock_1 = Lock(lock_folders[0])
+    lock_12 = Lock(lock_folders)
+
+    event.clear()
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, False, 0.2], {}),
+            ([lock_12, True, 0], {}),
+        ],
+        num_workers=2,
+    )
+    assert result == [1, 1]
+
+    # lock 1, then 1+2 + timeout
+
+    lock_1 = Lock(lock_folders[0])
+    lock_12 = Lock(lock_folders, timeout=0)
+
+    event.clear()
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, False, 0.2], {}),
+            ([lock_12, True, 0], {}),
+        ],
+        num_workers=2,
+    )
+    assert result == [1, 0]
+
+    # lock 1+2, then 1 + wait
+
+    lock_1 = Lock(lock_folders[0])
+    lock_12 = Lock(lock_folders)
+
+    event.clear()
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, True, 0], {}),
+            ([lock_12, False, 0.2], {}),
+        ],
+        num_workers=2,
+    )
+    assert result == [1, 1]
+
+    # lock 1+2, then 1 + timeout
+
+    lock_1 = Lock(lock_folders[0], timeout=0)
+    lock_12 = Lock(lock_folders)
+
+    event.clear()
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, True, 0], {}),
+            ([lock_12, False, 0.2], {}),
+        ],
+        num_workers=2,
+    )
+    assert result == [0, 1]
+
+    # lock 1+2, then 1 + wait and 2 + timeout
+
+    lock_1 = Lock(lock_folders[0])
+    lock_2 = Lock(lock_folders[1], timeout=0)
+    lock_12 = Lock(lock_folders)
+
+    event.clear()
+    result = audeer.run_tasks(
+        job,
+        [
+            ([lock_1, True, 0], {}),
+            ([lock_2, True, 0], {}),
+            ([lock_12, 0, 0.2], {}),
+        ],
+        num_workers=3,
+    )
+    assert result == [1, 0, 1]
+
+
+def test_lock_warning_and_failure(tmpdir):
+    """Test user warning and lock failure messages."""
+    path = audeer.path(tmpdir, "file.txt")
+    # Create lock file to force failing acquiring of lock
+    lock_file = audeer.touch(tmpdir, ".file.txt.lock")
+    lock_error = filelock.Timeout
+    lock_error_msg = f"The file lock '{lock_file}' could not be acquired."
+    warning_msg = (
+        "Lock could not be acquired immediately.\n"
+        "Another user might loading the same model.\n"
+        "Still trying for 0.1 more seconds..."
+    )
+    with pytest.warns(UserWarning, match=re.escape(warning_msg)):
+        with pytest.raises(lock_error, match=re.escape(lock_error_msg)):
+            with Lock(path, warning_timeout=0.1, timeout=0.2):
+                pass

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -27,17 +27,14 @@ def job(lock, wait, sleep):
 
 
 def test_lock(tmpdir):
-    # avoid displaying a warning
-    warning_timeout = 2
-
     # create two lock folders
 
     lock_folders = [audeer.mkdir(tmpdir, str(idx)) for idx in range(2)]
 
     # lock 1 and 2
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
-    lock_2 = lock(lock_folders[1], warning_timeout=warning_timeout)
+    lock_1 = lock(lock_folders[0], warn=False)
+    lock_2 = lock(lock_folders[1], warn=False)
 
     event.clear()
     result = audeer.run_tasks(
@@ -52,9 +49,9 @@ def test_lock(tmpdir):
 
     # lock 1, 2 and 1+2
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
-    lock_2 = lock(lock_folders[1], warning_timeout=warning_timeout)
-    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
+    lock_1 = lock(lock_folders[0], warn=False)
+    lock_2 = lock(lock_folders[1], warn=False)
+    lock_12 = lock(lock_folders, warn=False)
 
     result = audeer.run_tasks(
         job,
@@ -69,8 +66,8 @@ def test_lock(tmpdir):
 
     # lock 1, then 1+2 + wait
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
-    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
+    lock_1 = lock(lock_folders[0], warn=False)
+    lock_12 = lock(lock_folders, warn=False)
 
     event.clear()
     result = audeer.run_tasks(
@@ -85,8 +82,8 @@ def test_lock(tmpdir):
 
     # lock 1, then 1+2 + timeout
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
-    lock_12 = lock(lock_folders, warning_timeout=warning_timeout, timeout=0)
+    lock_1 = lock(lock_folders[0], warn=False)
+    lock_12 = lock(lock_folders, warn=False, timeout=0)
 
     event.clear()
     result = audeer.run_tasks(
@@ -101,8 +98,8 @@ def test_lock(tmpdir):
 
     # lock 1+2, then 1 + wait
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
-    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
+    lock_1 = lock(lock_folders[0], warn=False)
+    lock_12 = lock(lock_folders, warn=False)
 
     event.clear()
     result = audeer.run_tasks(
@@ -117,8 +114,8 @@ def test_lock(tmpdir):
 
     # lock 1+2, then 1 + timeout
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout, timeout=0)
-    lock_12 = lock(lock_folders, warning_timeout=warning_timeout)
+    lock_1 = lock(lock_folders[0], warn=False, timeout=0)
+    lock_12 = lock(lock_folders, warn=False)
 
     event.clear()
     result = audeer.run_tasks(
@@ -133,8 +130,8 @@ def test_lock(tmpdir):
 
     # lock 1+2, then 1 + wait and 2 + timeout
 
-    lock_1 = lock(lock_folders[0], warning_timeout=warning_timeout)
-    lock_2 = lock(lock_folders[1], warning_timeout=warning_timeout, timeout=0)
+    lock_1 = lock(lock_folders[0], warn=False)
+    lock_2 = lock(lock_folders[1], warn=False, timeout=0)
     lock_12 = lock(lock_folders)
 
     event.clear()
@@ -156,10 +153,10 @@ def test_lock_warning_and_failure(tmpdir):
     lock_file = audeer.touch(tmpdir, ".file.txt.lock")
     lock_error = filelock.Timeout
     lock_error_msg = f"The file lock '{lock_file}' could not be acquired."
-    warning_msg = f"Lock '{lock_file}' delayed; retrying for 0.1s."
+    warning_msg = f"Lock '{lock_file}' delayed; retrying for 0.2s."
     # Acquire first lock to force failing second lock
     with lock(path):
         with pytest.warns(UserWarning, match=re.escape(warning_msg)):
             with pytest.raises(lock_error, match=re.escape(lock_error_msg)):
-                with lock(path, warning_timeout=0.1, timeout=0.2):
+                with lock(path, warn=True, timeout=0.2):
                     pass


### PR DESCRIPTION
Closes #18 

Use a lock file to lock access to cache files when loading a model or its metadata.

The implementation is done with `filelock.FileLock` not `filelock.SoftFileLock` as in `audb` in order to avoid leftover lock files. The disadvantage is that this does not provide cross platform support.

Another difference to the implementation in `audb` is that we do not create the lock file within the requested cache folder. Instead we support creating lock files for folders and files. For a given path `a/b/c` the corresponding lock file is always located at `a/b/.c.lock`. The advantage is that we have the possibility to overwrite the whole folder, and lock only single files like the header.

I further added a new section to the usage section, discussing the limitations when using a shared cache:

<img width="717" height="161" alt="image" src="https://github.com/user-attachments/assets/bc1cc8b8-078c-43ba-9f15-1dccb3b58434" />


NOTE: I first wondered why we still need lock files, but `filelock.FileLock` also works with files, but in contrast to `filelock.SoftFileLock`, the lock file exists all the time and we try to acquire a lock on the file. So we never need to worry about leftover lock files.

## Summary by Sourcery

Lock cache operations when loading models to prevent concurrent access issues by introducing a file-based Lock class and integrating it into archive, header, and metadata loading routines

New Features:
- Introduce a Lock class using filelock.FileLock for file-based locking of cache paths

Enhancements:
- Wrap get_archive, get_header, and get_meta cache operations in the new Lock to avoid race conditions

Build:
- Add filelock as a project dependency

Tests:
- Add comprehensive tests for Lock behavior under concurrent access, timeouts, and warning scenarios

## Summary by Sourcery

Use file-based locks when loading model archives, headers, and metadata to prevent concurrent cache access issues

New Features:
- Implement a Lock class using filelock.FileLock for file- and folder-based locking

Enhancements:
- Wrap get_archive, get_header, and get_meta cache operations in the Lock to avoid race conditions
- Support locking single paths or multiple paths per Lock instance

Build:
- Add filelock as a project dependency

Documentation:
- Document shared cache locking limitations in the usage guide

Tests:
- Add tests for Lock under concurrent access, timeouts, and warning scenarios