### PR TITLE
audmodel.publish(): set default repository to None

### DIFF
--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -420,7 +420,7 @@ def publish(
     author: str | None = None,
     date: datetime.date | None = None,
     meta: dict[str, object] | None = None,
-    repository: Repository = config.REPOSITORIES[0],
+    repository: Repository | None = None,
     subgroup: str | None = None,
     verbose: bool = False,
 ) -> str:
@@ -491,7 +491,8 @@ def publish(
         author: author name(s), defaults to user name
         date: date, defaults to current timestamp
         meta: dictionary with meta information
-        repository: repository where the model will be published
+        repository: repository where the model will be published,
+            defaults to ``config.REPOSITORIES[0]``
         subgroup: subgroup under which
             the model is stored on backend.
             ``.`` are replaced by ``/``
@@ -564,6 +565,9 @@ def publish(
     """  # noqa: E501
     root = audeer.safe_path(root)
     subgroup = subgroup or ""
+
+    if repository is None:
+        repository = config.REPOSITORIES[0]
 
     if subgroup == define.UID_FOLDER:
         raise ValueError(f"It is not allowed to set subgroup to '{define.UID_FOLDER}'.")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -25,7 +25,7 @@ SUBGROUP = f"{pytest.ID}.publish"
             pytest.DATE,
             pytest.META["1.0.0"],
             SUBGROUP,
-            audmodel.config.REPOSITORIES[0],
+            None,
         ),
         # different name
         pytest.param(


### PR DESCRIPTION
Closes #30 

<img width="759" height="1180" alt="image" src="https://github.com/user-attachments/assets/4d2f4671-377d-48e4-a60c-1801a043398d" />

## Summary by Sourcery

Set default repository parameter in audmodel.publish() to None with internal fallback to maintain existing behavior, and adjust documentation and tests accordingly

Enhancements:
- Accept None as default for repository in publish() and fallback to the first configured repository internally

Documentation:
- Update publish() docstring to describe the new default repository behavior

Tests:
- Update publish() tests to use None as the default repository argument instead of explicit repository