### PR TITLE
DOC: usage documentation for model aliases

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -304,7 +304,7 @@ To find the latest version we can do:
 
     audmodel.latest_version(uid)
 
-We can now also update our existing model aliases
+We can update our existing model aliases
 to point to the newest version.
 
 .. jupyter-execute::


### PR DESCRIPTION
Closes #29 

Add usage documentation for the new model alias feature.

<img width="709" height="857" alt="image" src="https://github.com/user-attachments/assets/df185fb1-ab3e-458c-b6df-5105a6a2efb7" />

and new part in "Publish a new version" sub-section

<img width="716" height="375" alt="image" src="https://github.com/user-attachments/assets/eb211b05-44a9-40c7-947b-205bc073fc58" />


## Summary by Sourcery

Documentation:
- Document the model alias syntax and provide usage examples in the usage guide