### PR TITLE
Add num_workers to load()

### DIFF
--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -278,6 +278,7 @@ def load(
     *,
     cache_root: str | None = None,
     timeout: float = 14400,  # 4 h
+    num_workers: int = 1,
     verbose: bool = False,
 ) -> str:
     r"""Download a model by its unique ID.
@@ -294,6 +295,7 @@ def load(
             If not set :meth:`audmodel.default_cache_root` is used
         timeout: maximum time in seconds
             before giving up acquiring a lock
+        num_workers: number of parallel jobs
         verbose: show debug messages
 
     Returns:
@@ -313,7 +315,7 @@ def load(
     """
     cache_root = audeer.safe_path(cache_root or default_cache_root())
     short_id, version = split_uid(uid, cache_root)
-    return get_archive(short_id, version, cache_root, timeout, verbose)
+    return get_archive(short_id, version, cache_root, timeout, num_workers, verbose)
 
 
 def meta(

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -60,6 +60,7 @@ def get_archive(
     version: str,
     cache_root: str,
     timeout: float,
+    num_workers: int,
     verbose: bool,
 ) -> str:
     r"""Return backend and local archive path.
@@ -70,6 +71,7 @@ def get_archive(
         cache_root: path of cache root
         timeout: maximum time in seconds
             before giving up acquiring a lock
+        num_workers: number of parallel jobs
         verbose: if ``True`` show message
             or progress bar
             when downloading file
@@ -106,6 +108,7 @@ def get_archive(
                     src_path,
                     dst_path,
                     version,
+                    num_workers=num_workers,
                     verbose=verbose,
                 )
 
@@ -114,6 +117,7 @@ def get_archive(
                 dst_path,
                 tmp_root,
                 keep_archive=False,
+                num_workers=num_workers,
                 verbose=verbose,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] @ git+https://github.com/audeering/audbackend.git@workers-download',
+    'audbackend[all] >=2.3.0',
     'audeer @ git+https://github.com/audeering/audeer.git@archive-num-workers-2',
     'filelock',
     'oyaml',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] >=2.2.2',
+    'audbackend[all] @ git+https://github.com/audeering/audbackend.git@workers-download',
     'filelock',
     'oyaml',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] @ git+https://github.com/audeering/audbackend.git@workers-download',
+    'audeer @ git+https://https://github.com/audeering/audeer.git@archive-num-workers-2',
     'filelock',
     'oyaml',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] @ git+https://github.com/audeering/audbackend.git@workers-download',
-    'audeer @ git+https://https://github.com/audeering/audeer.git@archive-num-workers-2',
+    'audeer @ git+https://github.com/audeering/audeer.git@archive-num-workers-2',
     'filelock',
     'oyaml',
 ]


### PR DESCRIPTION
Adds `num_workers` to `audmodel.load()` to speed up model loading from backends that support downloads using multiple workers.

This requires a development version of `audbackend` and `audeer` at the moment.

## Benchmarks

All benchmarks use the model `7289b57d-1.0.0` (4.2 GB).

| num_workers | Before | After | After + https://github.com/audeering/audeer/pull/186 |
| --- | --- | --- | --- |
| 1 |   |   | 0:02:13.382400 |
| 2 |   |   | 0:02:06.741217 |
| 3 |   |   | 0:02:00.317035 |
| 4 |   |   | 0:02:00.812837 |
| 5 |   |   | 0:02:00.533920 |
| 10 |   |   | 0:02:00.036849 |



I run the benchmark with
```bash
$ uv run --python 3.12 benchmark-audmodel.py
```

<details><summary>benchmark-audmodel.py</summary>

```python
# /// script
# dependencies = [
#   "audmodel",
#   "numpy",
#   "pandas",
#   "tabulate",
# ]
# [tool.uv.sources]
# audmodel = { path = ".", editable = true }
# ///
import datetime
import tempfile
import time

import numpy as np
import pandas as pd

import audeer
import audmodel


def main():

    model_id = "7289b57d-1.0.0"
    num_iter = 10

    ds = []
    for num_workers in audeer.progress_bar([1, 2, 3, 4, 5, 10]):
        elapsed = []
        for _ in range(num_iter):
            with tempfile.TemporaryDirectory() as cache_root:
                t = time.time()
                audmodel.load(
                    model_id,
                    cache_root=cache_root,
                    num_workers=num_workers,
                    verbose=False,
                )
                elapsed.append(time.time() - t)

        ds.append(
            {
                "num_workers": num_workers,
                "num_iter": num_iter,
                "elapsed(avg)": str(datetime.timedelta(seconds=np.mean(elapsed))),
                "elapsed(std)": str(datetime.timedelta(seconds=np.std(elapsed))),
            }
        )

    df = pd.DataFrame(ds)
    df.to_csv(f"results.csv", index=False)
    df.to_markdown(f"results.md", index=False)


if __name__ == "__main__":
    main()
```

</details>

Performance when using the single-threaded implementations of `audeer` and `audbackend`:


|   num_workers |   num_iter | elapsed(avg)   | elapsed(std)   |   
|--------------:|-----------:|:---------------|:---------------|
|             1 |         10 | 0:02:17.690002 | 0:00:05.033113 |

When using only multiple workers with `audbackend`, performance gets only slightly better. So most likely the archive extraction is costly.

|   num_workers |   num_iter | elapsed(avg)   | elapsed(std)   |   
|--------------:|-----------:|:---------------|:---------------|
|             1 |         10 | 0:02:23.903513 | 0:00:05.744711 |
|             2 |         10 | 0:02:14.147027 | 0:00:07.193578 |
|             3 |         10 | 0:02:09.759947 | 0:00:00.829281 |
|             4 |         10 | 0:02:10.224645 | 0:00:00.940978 |
|             5 |         10 | 0:02:12.284520 | 0:00:03.940332 |
|            10 |         10 | 0:02:11.610993 | 0:00:01.676725 |

When using multiple workers with `audbackend` and `audeer`, performance only slightly gets better. I think the biggest problem is that we store the model in a single big file. Using multiple workers during extraction of the archive is only efficient if the model would be stored in several smaller chunks.

|   num_workers |   num_iter | elapsed(avg)   | elapsed(std)   |   
|--------------:|-----------:|:---------------|:---------------|
|             1 |         10 | 0:02:13.382400 | 0:00:03.332782 |
|             2 |         10 | 0:02:06.741217 | 0:00:00.941959 |
|             3 |         10 | 0:02:00.317035 | 0:00:00.878243 |
|             4 |         10 | 0:02:00.812837 | 0:00:01.087174 |
|             5 |         10 | 0:02:00.533920 | 0:00:01.224509 |
|            10 |         10 | 0:02:00.036849 | 0:00:01.653377 |


## Summary by Sourcery

Introduce a num_workers parameter to the model loading API and backend to enable parallel downloads, and update the audbackend dependency to a development branch that supports multi-worker downloads.

New Features:
- Add num_workers argument to audmodel.load() to configure parallel download jobs
- Propagate num_workers through get_archive and backend download functions for concurrency support

Build:
- Update audbackend dependency to the workers-download development branch for multi-worker download support