### PR TITLE
Require audbackend[all] >=2.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] >=2.2.2',
+    'audbackend[all] >=2.2.3',
     'filelock',
     'oyaml',
 ]


### PR DESCRIPTION
Make sure we use the new `audbackend` version that fixes the `minio` issue.