### PR TITLE
Use streaming ZIP extraction

### DIFF
--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -100,22 +100,12 @@ def get_archive(
 
             with backend_interface.backend:
                 # get archive
-                src_path = path
-                dst_path = os.path.join(tmp_root, "model.zip")
-                backend_interface.get_file(
-                    src_path,
-                    dst_path,
+                backend_interface.get_archive(
+                    path,
+                    tmp_root,
                     version,
                     verbose=verbose,
                 )
-
-            # extract files
-            audeer.extract_archive(
-                dst_path,
-                tmp_root,
-                keep_archive=False,
-                verbose=verbose,
-            )
 
             # move tmp folder to final destination
             if os.path.exists(root):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] >=2.2.3',
+    'audbackend[all] @ git+https://github.com/audeering/audbackend.git@stream-extract',
     'filelock',
     'oyaml',
 ]


### PR DESCRIPTION
Use streaming ZIP extraction from https://github.com/audeering/audbackend/pull/279 to speed up downloading models (with a single worker).

Execution time to load `7289b57d-1.0.0` (4.2 GB).

| Before | After |
| --- | --- |
| 0:02:21.247691 | 0:01:20.056608 |

## Summary by Sourcery

Streamline model archive retrieval by leveraging backend-level streaming extraction instead of downloading and unpacking ZIP files locally.

Enhancements:
- Replace local ZIP download and extraction with backend_interface.get_archive to support streaming extraction of model archives.

Build:
- Update audbackend dependency to a git-based stream-extract branch to enable streaming archive support.