### PR TITLE
Group wirte permissions for lock files

### DIFF
--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -9,18 +9,12 @@ from filelock import Timeout
 import audeer
 
 
-#: File permissions for lock files.
-#: We use ``0o664`` (``-rw-rw-r--``)
-#: to allow group-write access,
-#: which is needed for shared caches.
-_LOCK_FILE_MODE = 0o664
-
-
 @contextmanager
 def lock(
     paths: list[str],
     *,
     timeout: float = 10,
+    mode: int = 0o664,
     warn: bool = True,
 ):
     """Create lock for given paths.
@@ -31,6 +25,10 @@ def lock(
             before giving up acquiring a lock.
             If timeout is reached,
             an exception is raised
+        mode: file permissions for lock files.
+            We use ``0o664`` (``-rw-rw-r--``)
+            to allow group-write access,
+            which is needed for shared caches
         warn: if ``True``
             a warning is shown to the user
             if the lock cannot be acquired
@@ -39,7 +37,7 @@ def lock(
 
     """
     lock_files = _lock_files(paths)
-    locks = [FileLock(f, timeout=timeout, mode=_LOCK_FILE_MODE) for f in lock_files]
+    locks = [FileLock(f, timeout=timeout, mode=mode) for f in lock_files]
     with ExitStack() as stack:
         for lock, f in zip(locks, lock_files):
             acquired = False

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -58,11 +58,14 @@ def lock(
 
 
 def _lock_files(paths: list[str]) -> list[str]:
-    """Create lock files if not existent.
+    """Return lock file paths for given paths.
 
-    The lock files are created outside the folder,
+    The lock files are placed outside the folder,
     to allow to delete/overwrite the folder
     by the process.
+
+    The lock files themselves are created
+    by :class:`filelock.FileLock` during acquisition.
 
     Args:
         paths: files or folders that should be locked
@@ -77,8 +80,5 @@ def _lock_files(paths: list[str]) -> list[str]:
         dirname = audeer.mkdir(os.path.dirname(path))
         basename = os.path.basename(path)
         lock_file = audeer.path(dirname, f".{basename}.lock")
-        if not os.path.exists(lock_file):
-            audeer.touch(lock_file)
-            os.chmod(lock_file, _LOCK_FILE_MODE)
         lock_files.append(lock_file)
     return lock_files

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -9,12 +9,18 @@ from filelock import Timeout
 import audeer
 
 
+#: File permissions for lock files.
+#: We use ``0o664`` (``-rw-rw-r--``)
+#: to allow group-write access,
+#: which is needed for shared caches.
+_LOCK_FILE_MODE = 0o664
+
+
 @contextmanager
 def lock(
     paths: list[str],
     *,
     timeout: float = 10,
-    mode: int = 0o664,
     warn: bool = True,
 ):
     """Create lock for given paths.
@@ -25,10 +31,6 @@ def lock(
             before giving up acquiring a lock.
             If timeout is reached,
             an exception is raised
-        mode: file permissions for lock files.
-            We use ``0o664`` (``-rw-rw-r--``)
-            to allow group-write access,
-            which is needed for shared caches
         warn: if ``True``
             a warning is shown to the user
             if the lock cannot be acquired
@@ -37,7 +39,7 @@ def lock(
 
     """
     lock_files = _lock_files(paths)
-    locks = [FileLock(f, timeout=timeout, mode=mode) for f in lock_files]
+    locks = [FileLock(f, timeout=timeout, mode=_LOCK_FILE_MODE) for f in lock_files]
     with ExitStack() as stack:
         for lock, f in zip(locks, lock_files):
             acquired = False

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -9,6 +9,24 @@ from filelock import Timeout
 import audeer
 
 
+def _acquire_with_umask(lock, *, timeout):
+    """Acquire lock with group-write friendly umask.
+
+    ``filelock.FileLock`` may create the lock file
+    during acquisition.
+    We set umask to ``0o002``
+    to ensure the lock file is created
+    with group-write permissions,
+    which is needed in shared caches.
+
+    """
+    old_mask = os.umask(0o002)
+    try:
+        lock.acquire(timeout=timeout)
+    finally:
+        os.umask(old_mask)
+
+
 @contextmanager
 def lock(
     paths: list[str],
@@ -38,14 +56,14 @@ def lock(
             acquired = False
             if warn:
                 try:
-                    lock.acquire(timeout=0)
+                    _acquire_with_umask(lock, timeout=0)
                     acquired = True
                 except Timeout:
                     warnings.warn(
                         f"Could not acquire lock '{f}'; retrying for {timeout}s."
                     )
             if not acquired:
-                lock.acquire(timeout=timeout)
+                _acquire_with_umask(lock, timeout=timeout)
             stack.enter_context(lock)
         yield
 
@@ -71,6 +89,10 @@ def _lock_files(paths: list[str]) -> list[str]:
         basename = os.path.basename(path)
         lock_file = audeer.path(dirname, f".{basename}.lock")
         if not os.path.exists(lock_file):
-            audeer.touch(lock_file)
+            old_mask = os.umask(0o002)
+            try:
+                audeer.touch(lock_file)
+            finally:
+                os.umask(old_mask)
         lock_files.append(lock_file)
     return lock_files

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -9,10 +9,10 @@ from filelock import Timeout
 import audeer
 
 
-#: File permissions for lock files.
-#: We use ``0o664`` (``-rw-rw-r--``)
-#: to allow group-write access,
-#: which is needed for shared caches.
+# File permissions for lock files.
+# We use `0o664` (`-rw-rw-r--`)
+# to allow group-write access,
+# which is needed for shared caches.
 _LOCK_FILE_MODE = 0o664
 
 

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -58,16 +58,14 @@ def lock(
 
 
 def _lock_files(paths: list[str]) -> list[str]:
-    """Create lock files if not existent.
+    """Return lock file paths for given paths.
 
-    The lock files are created outside the folder,
+    The lock files are placed outside the folder,
     to allow to delete/overwrite the folder
     by the process.
 
-    Lock files are created with group-write permissions
-    (``-rw-rw-r--``)
-    to allow shared cache usage
-    across users of the same group.
+    The lock files themselves are created
+    by :class:`filelock.FileLock` during acquisition.
 
     Args:
         paths: files or folders that should be locked
@@ -82,8 +80,5 @@ def _lock_files(paths: list[str]) -> list[str]:
         dirname = audeer.mkdir(os.path.dirname(path))
         basename = os.path.basename(path)
         lock_file = audeer.path(dirname, f".{basename}.lock")
-        if not os.path.exists(lock_file):
-            audeer.touch(lock_file)
-            os.chmod(lock_file, _LOCK_FILE_MODE)
         lock_files.append(lock_file)
     return lock_files

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -58,14 +58,16 @@ def lock(
 
 
 def _lock_files(paths: list[str]) -> list[str]:
-    """Return lock file paths for given paths.
+    """Create lock files if not existent.
 
-    The lock files are placed outside the folder,
+    The lock files are created outside the folder,
     to allow to delete/overwrite the folder
     by the process.
 
-    The lock files themselves are created
-    by :class:`filelock.FileLock` during acquisition.
+    Lock files are created with group-write permissions
+    (``-rw-rw-r--``)
+    to allow shared cache usage
+    across users of the same group.
 
     Args:
         paths: files or folders that should be locked
@@ -80,5 +82,8 @@ def _lock_files(paths: list[str]) -> list[str]:
         dirname = audeer.mkdir(os.path.dirname(path))
         basename = os.path.basename(path)
         lock_file = audeer.path(dirname, f".{basename}.lock")
+        if not os.path.exists(lock_file):
+            audeer.touch(lock_file)
+            os.chmod(lock_file, _LOCK_FILE_MODE)
         lock_files.append(lock_file)
     return lock_files

--- a/audmodel/core/lock.py
+++ b/audmodel/core/lock.py
@@ -9,22 +9,11 @@ from filelock import Timeout
 import audeer
 
 
-def _acquire_with_umask(lock, *, timeout):
-    """Acquire lock with group-write friendly umask.
-
-    ``filelock.FileLock`` may create the lock file
-    during acquisition.
-    We set umask to ``0o002``
-    to ensure the lock file is created
-    with group-write permissions,
-    which is needed in shared caches.
-
-    """
-    old_mask = os.umask(0o002)
-    try:
-        lock.acquire(timeout=timeout)
-    finally:
-        os.umask(old_mask)
+#: File permissions for lock files.
+#: We use ``0o664`` (``-rw-rw-r--``)
+#: to allow group-write access,
+#: which is needed for shared caches.
+_LOCK_FILE_MODE = 0o664
 
 
 @contextmanager
@@ -50,20 +39,20 @@ def lock(
 
     """
     lock_files = _lock_files(paths)
-    locks = [FileLock(f, timeout=timeout) for f in lock_files]
+    locks = [FileLock(f, timeout=timeout, mode=_LOCK_FILE_MODE) for f in lock_files]
     with ExitStack() as stack:
         for lock, f in zip(locks, lock_files):
             acquired = False
             if warn:
                 try:
-                    _acquire_with_umask(lock, timeout=0)
+                    lock.acquire(timeout=0)
                     acquired = True
                 except Timeout:
                     warnings.warn(
                         f"Could not acquire lock '{f}'; retrying for {timeout}s."
                     )
             if not acquired:
-                _acquire_with_umask(lock, timeout=timeout)
+                lock.acquire(timeout=timeout)
             stack.enter_context(lock)
         yield
 
@@ -89,10 +78,7 @@ def _lock_files(paths: list[str]) -> list[str]:
         basename = os.path.basename(path)
         lock_file = audeer.path(dirname, f".{basename}.lock")
         if not os.path.exists(lock_file):
-            old_mask = os.umask(0o002)
-            try:
-                audeer.touch(lock_file)
-            finally:
-                os.umask(old_mask)
+            audeer.touch(lock_file)
+            os.chmod(lock_file, _LOCK_FILE_MODE)
         lock_files.append(lock_file)
     return lock_files

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -149,6 +149,7 @@ def test_lock(tmpdir):
     assert set(result) == {0, 1}
 
 
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions required")
 def test_lock_file_permissions(tmpdir):
     """Lock files are created with group-write permissions."""
     path = audeer.path(tmpdir, "file.txt")

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -156,10 +156,8 @@ def test_lock_file_permissions(tmpdir):
     lock_file = audeer.path(tmpdir, ".file.txt.lock")
 
     with lock(path, warn=False):
-        pass
-
-    mode = os.stat(lock_file).st_mode
-    assert mode & stat.S_IWGRP
+        mode = os.stat(lock_file).st_mode
+        assert mode & stat.S_IWGRP
 
 
 def test_lock_warning_and_failure(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -158,16 +158,7 @@ def test_lock_file_permissions(tmpdir):
         pass
 
     mode = os.stat(lock_file).st_mode
-    assert mode & stat.S_IWGRP, "Lock file should have group-write permission"
-
-    # Remove lock file so next lock() recreates it via FileLock.acquire
-    os.remove(lock_file)
-
-    with lock(path, warn=False):
-        pass
-
-    mode = os.stat(lock_file).st_mode
-    assert mode & stat.S_IWGRP, "Recreated lock file should have group-write permission"
+    assert mode & stat.S_IWGRP
 
 
 def test_lock_warning_and_failure(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -156,8 +156,10 @@ def test_lock_file_permissions(tmpdir):
     lock_file = audeer.path(tmpdir, ".file.txt.lock")
 
     with lock(path, warn=False):
-        mode = os.stat(lock_file).st_mode
-        assert mode & stat.S_IWGRP
+        pass
+
+    mode = os.stat(lock_file).st_mode
+    assert mode & stat.S_IWGRP
 
 
 def test_lock_warning_and_failure(tmpdir):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,6 @@
+import os
 import re
+import stat
 import threading
 import time
 
@@ -145,6 +147,27 @@ def test_lock(tmpdir):
         num_workers=3,
     )
     assert set(result) == {0, 1}
+
+
+def test_lock_file_permissions(tmpdir):
+    """Lock files are created with group-write permissions."""
+    path = audeer.path(tmpdir, "file.txt")
+    lock_file = audeer.path(tmpdir, ".file.txt.lock")
+
+    with lock(path, warn=False):
+        pass
+
+    mode = os.stat(lock_file).st_mode
+    assert mode & stat.S_IWGRP, "Lock file should have group-write permission"
+
+    # Remove lock file so next lock() recreates it via FileLock.acquire
+    os.remove(lock_file)
+
+    with lock(path, warn=False):
+        pass
+
+    mode = os.stat(lock_file).st_mode
+    assert mode & stat.S_IWGRP, "Recreated lock file should have group-write permission"
 
 
 def test_lock_warning_and_failure(tmpdir):


### PR DESCRIPTION
Closes #40 

Create lock files with group write permissions and use `filelock.Filelock` to create the file instead of `audeer.touch()`.

Before, we used `audeer.touch()` to create the file as `filelock.Filelock` was not removing files in older versions, but this changed in newer versions, see https://github.com/tox-dev/filelock/commit/03b0ab7ea566b1d1385274d185e5e590cdaa6872.