### PR TITLE
Include only audmodel* in Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,11 +218,7 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
-exclude = [
-    'tests*',
-    'docs*',
-    'misc*',
-]
+include = ['audmodel*']
 
 # ----- setuptools_scm ----------------------------------------------------
 #


### PR DESCRIPTION
This restricts the files included in the Python package to `audmodel*`.

Same fix as audeering/audb#560 (audeering/audb#559). The previous `exclude = ['tests*', 'docs*', 'misc*']` blacklist worked but is fragile — any new top-level directory (e.g. `examples/`, `notebooks/`, `benchmarks/`) would silently be packaged and end up under `site-packages/`, shadowing local packages of the same name in downstream projects. Switching to a `include` whitelist makes the intent explicit and future-proof.