### PR TITLE
Add tmp_root argument to publish()

### DIFF
--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -518,7 +518,10 @@ def publish(
             on the backend
         tmp_root: folder under which the temporary archive
             of the model is created before uploading.
-            The folder is created if it does not exist.
+            The folder is created if it does not exist,
+            and is kept afterwards;
+            only the temporary archive inside it
+            is removed when publishing finishes.
             If ``None``,
             the system default temporary folder is used
         verbose: show debug messages

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -437,6 +437,7 @@ def publish(
     meta: dict[str, object] | None = None,
     repository: Repository | None = None,
     subgroup: str | None = None,
+    tmp_root: str | None = None,
     verbose: bool = False,
 ) -> str:
     r"""Zip model and publish as a new artifact.
@@ -515,6 +516,11 @@ def publish(
             the model is stored on backend.
             ``.`` are replaced by ``/``
             on the backend
+        tmp_root: folder under which the temporary archive
+            of the model is created before uploading.
+            The folder is created if it does not exist.
+            If ``None``,
+            the system default temporary folder is used
         verbose: show debug messages
 
     Returns:
@@ -651,6 +657,7 @@ def publish(
             root,
             backend_interface,
             verbose,
+            tmp_root=tmp_root,
         )
         if alias:
             # Store mapping (alias -> UID)

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -415,8 +415,8 @@ def put_archive(
     if tmp_root is not None:
         tmp_root = audeer.mkdir(tmp_root)
 
-    with tempfile.TemporaryDirectory(dir=tmp_root) as tmp_root:
-        src_path = os.path.join(tmp_root, "model.zip")
+    with tempfile.TemporaryDirectory(dir=tmp_root) as archive_root:
+        src_path = os.path.join(archive_root, "model.zip")
         files = utils.scan_files(root)
         audeer.create_archive(
             root,

--- a/audmodel/core/backend.py
+++ b/audmodel/core/backend.py
@@ -379,6 +379,7 @@ def put_archive(
     root: str,
     backend_interface: audbackend.interface.Maven,
     verbose: bool,
+    tmp_root: str | None = None,
 ) -> str:
     r"""Put archive to backend.
 
@@ -391,6 +392,10 @@ def put_archive(
         backend_interface: backend interface instance
         verbose: if ``True`` show message
             when uploading file
+        tmp_root: folder under which the temporary archive
+            is created.
+            If ``None``,
+            the system default temporary folder is used
 
     Returns:
         archive path on backend
@@ -407,7 +412,10 @@ def put_archive(
         short_id + ".zip",
     )
 
-    with tempfile.TemporaryDirectory() as tmp_root:
+    if tmp_root is not None:
+        tmp_root = audeer.mkdir(tmp_root)
+
+    with tempfile.TemporaryDirectory(dir=tmp_root) as tmp_root:
         src_path = os.path.join(tmp_root, "model.zip")
         files = utils.scan_files(root)
         audeer.create_archive(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import audbackend
+import audeer
 
 import audmodel
 
@@ -249,3 +250,33 @@ def test_publish_error(params, meta, repository, error, error_msg):
         version,
     )
     assert not audmodel.exists(uid)
+
+
+def test_publish_tmp_root(tmp_path):
+    r"""Test publishing with a custom ``tmp_root`` folder.
+
+    The archive should be staged inside ``tmp_root``
+    and the folder should be created
+    if it does not exist yet.
+
+    """
+    tmp_root = os.path.join(tmp_path, "does", "not", "exist")
+    assert not os.path.exists(tmp_root)
+
+    uid = audmodel.publish(
+        pytest.MODEL_ROOT,
+        pytest.NAME,
+        {"tmp_root": "custom"},
+        "1.0.0",
+        author=pytest.AUTHOR,
+        date=pytest.DATE,
+        subgroup=f"{SUBGROUP}.tmp_root",
+        tmp_root=tmp_root,
+    )
+
+    assert audmodel.exists(uid)
+    # ``tmp_root`` is created on demand,
+    # and ``TemporaryDirectory`` cleans up its content,
+    # but the folder we created stays around
+    assert os.path.isdir(tmp_root)
+    assert audeer.list_file_names(tmp_root) == []


### PR DESCRIPTION
Closes #44 

Adds `tmp_root` as argument to `audb.publish()`. When not `None` the archive with the model files will be generated inside the provided folder.

<img width="664" height="103" alt="image" src="https://github.com/user-attachments/assets/304cc371-ee09-48ee-ab29-2ae5925a319e" />

