### PR TITLE
Update first repo to ...

### DIFF
--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -9,9 +9,9 @@ class config:
 
     REPOSITORIES = [
         Repository(
-            "models-local",
-            "https://artifactory.audeering.com/artifactory",
-            "artifactory",
+            "...",
+            "...",
+            "s3",
         ),
         Repository(
             "audmodel-internal",


### PR DESCRIPTION
As we move away from Artifactory (compare https://github.com/audeering/audbackend/pull/296) we switch the new first default repository to `...` on `...`.