### PR TITLE
Add audmodel.yaml config file

### DIFF
--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -1,22 +1,118 @@
+import os
+
+import oyaml as yaml
+
+import audeer
+
+from audmodel.core.define import CONFIG_FILE
+from audmodel.core.define import USER_CONFIG_FILE
 from audmodel.core.repository import Repository
 
 
-class config:
-    r"""Get/set defaults for the :mod:`audmodel` module."""
+CWD = audeer.script_dir()
+global_config_file = os.path.join(CWD, CONFIG_FILE)
 
-    CACHE_ROOT = "~/audmodel"
+
+def load_configuration_file(config_file: str) -> dict:
+    r"""Read configuration from YAML file.
+
+    Args:
+        config_file: path to configuration file.
+            File doesn't have to exist
+
+    Returns:
+        dictionary containing configuration entries
+
+    Raises:
+        ValueError: if ``repositories`` section is present,
+            but empty
+        ValueError: if repository has no ``host``
+            ``backend``, or ``name`` key
+
+    """
+    if not os.path.exists(config_file):
+        return {}
+
+    with open(config_file) as cf:
+        config = yaml.load(cf, Loader=yaml.BaseLoader)
+        if config is None:
+            return {}
+
+    # Check that we have provided a valid repositories configuration
+    if "repositories" in config:
+        if len(config["repositories"]) == 0:
+            raise ValueError(
+                "You cannot specify an empty 'repositories:' section "
+                f"in the configuration file '{USER_CONFIG_FILE}'."
+            )
+        for repo in config["repositories"]:
+            if "host" not in repo:
+                raise ValueError(
+                    f"Your repository is missing a 'host' entry: '{repo}'."
+                )
+            if "backend" not in repo:
+                raise ValueError(
+                    f"Your repository is missing a 'backend' entry: '{repo}'."
+                )
+            if "name" not in repo:
+                raise ValueError(
+                    f"Your repository is missing a 'name' entry: '{repo}'."
+                )
+
+    return config
+
+
+def load_config() -> dict:
+    """Read configuration from configuration files.
+
+    User config values take precedence over global config values
+    when the same setting exists in both files.
+
+    """
+    # Global config
+    config = load_configuration_file(global_config_file)
+    # User config
+    user_config = load_configuration_file(audeer.path(USER_CONFIG_FILE))
+    config.update(user_config)
+    return config
+
+
+class config:
+    """Get/set configuration values for the :mod:`audmodel` module.
+
+    The configuration values are read in during module import
+    from the :ref:`configuration file <configuration>`
+    :file:`~/.config/audmodel.yaml`.
+    You can change the configuration values after import,
+    by setting the attributes directly.
+    The cache related configuration value :attr:`config.CACHE_ROOT`
+    can be overwritten by the ``AUDMODEL_CACHE_ROOT`` environment variable.
+
+    Examples:
+        >>> config.CACHE_ROOT = "~/caches/audmodel"
+        >>> config.CACHE_ROOT
+        '~/caches/audmodel'
+
+    """
+
+    _config = load_config()
+
+    CACHE_ROOT = _config["cache_root"]
     r"""Default cache folder for storing models."""
 
     REPOSITORIES = [
-        Repository(
-            "models-local",
-            "https://artifactory.audeering.com/artifactory",
-            "artifactory",
-        ),
-        Repository(
-            "audmodel-internal",
-            "s3.dualstack.eu-north-1.amazonaws.com",
-            "s3",
-        ),
+        Repository(r["name"], r["host"], r["backend"]) for r in _config["repositories"]
     ]
-    r"""Default repositories (will be searched in given order)."""
+    r"""Repositories, will be iterated in given order.
+
+    A repository is defined by the object :class:`audmodel.Repository`,
+    containing the following attributes:
+
+    * :attr:`audmodel.Repository.name`: repository name,
+      e.g. ``"models-local"``
+    * :attr:`audmodel.Repository.backend`: backend name,
+      e.g. ``"s3"``
+    * :attr:`audmodel.Repository.host`: host name,
+      e.g. ``"s3.dualstack.eu-north-1.amazonaws.com"``
+
+    """

--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -43,7 +43,7 @@ def load_configuration_file(config_file: str) -> dict:
         if len(config["repositories"]) == 0:
             raise ValueError(
                 "You cannot specify an empty 'repositories:' section "
-                f"in the configuration file '{USER_CONFIG_FILE}'."
+                f"in the configuration file '{config_file}'."
             )
         for repo in config["repositories"]:
             for key in ("host", "backend", "name"):

--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -86,7 +86,7 @@ class config:
     You can change the configuration values after import,
     by setting the attributes directly.
     The cache related configuration value :attr:`config.CACHE_ROOT`
-    can be overwritten by the ``AUDMODEL_CACHE_ROOT`` environment variable.
+    can be overridden by the ``AUDMODEL_CACHE_ROOT`` environment variable.
 
     Examples:
         >>> config.CACHE_ROOT = "~/caches/audmodel"

--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -46,18 +46,11 @@ def load_configuration_file(config_file: str) -> dict:
                 f"in the configuration file '{USER_CONFIG_FILE}'."
             )
         for repo in config["repositories"]:
-            if "host" not in repo:
-                raise ValueError(
-                    f"Your repository is missing a 'host' entry: '{repo}'."
-                )
-            if "backend" not in repo:
-                raise ValueError(
-                    f"Your repository is missing a 'backend' entry: '{repo}'."
-                )
-            if "name" not in repo:
-                raise ValueError(
-                    f"Your repository is missing a 'name' entry: '{repo}'."
-                )
+            for key in ("host", "backend", "name"):
+                if key not in repo:
+                    raise ValueError(
+                        f"Your repository is missing a '{key}' entry: '{repo}'."
+                    )
 
     return config
 

--- a/audmodel/core/conftest.py
+++ b/audmodel/core/conftest.py
@@ -7,6 +7,7 @@ import audmodel
 def docstring_examples(doctest_namespace):  # pragma: no cover
     r"""Publish model for doctests."""
     repository = pytest.REPOSITORIES[0]
+    cache_root = audmodel.config.CACHE_ROOT
     audmodel.config.REPOSITORIES = [repository]
     subgroup = "audmodel.dummy.cnn"
     for version, meta in pytest.META.items():
@@ -33,3 +34,4 @@ def docstring_examples(doctest_namespace):  # pragma: no cover
     doctest_namespace["repository"] = repository
     yield
     audmodel.config.REPOSITORIES = pytest.REPOSITORIES
+    audmodel.config.CACHE_ROOT = cache_root

--- a/audmodel/core/define.py
+++ b/audmodel/core/define.py
@@ -1,3 +1,13 @@
+import os
+
+
+# Configuration files
+CONFIG_FILE = os.path.join("etc", "audmodel.yaml")
+r"""Path to default configuration file shipped with the package."""
+
+USER_CONFIG_FILE = "~/.config/audmodel.yaml"
+r"""Path to user configuration file."""
+
 HEADER_EXT = "header.yaml"
 r"""Extension of header file."""
 

--- a/audmodel/core/etc/audmodel.yaml
+++ b/audmodel/core/etc/audmodel.yaml
@@ -1,0 +1,8 @@
+cache_root: ~/audmodel
+repositories:
+  - name: models-local
+    backend: artifactory
+    host: https://artifactory.audeering.com/artifactory
+  - name: audmodel-internal
+    backend: s3
+    host: s3.dualstack.eu-north-1.amazonaws.com

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,7 +5,7 @@ Configuration
 
 :mod:`audmodel` can be configured with a :file:`~/.config/audmodel.yaml` file.
 The configuration file is read during import
-and will overwrite the default settings.
+and will override the default settings.
 The default settings are:
 
 .. literalinclude:: ../audmodel/core/etc/audmodel.yaml
@@ -27,5 +27,5 @@ using :class:`audmodel.config`.
 '/user/cache'
 
 The cache folder
-can also be overwritten
+can also be overridden
 with the ``AUDMODEL_CACHE_ROOT`` environment variable.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,31 @@
+.. _configuration:
+
+Configuration
+=============
+
+:mod:`audmodel` can be configured with a :file:`~/.config/audmodel.yaml` file.
+The configuration file is read during import
+and will overwrite the default settings.
+The default settings are:
+
+.. literalinclude:: ../audmodel/core/etc/audmodel.yaml
+    :language: yaml
+
+After loading :mod:`audmodel`
+they can be accessed
+or changed
+using :class:`audmodel.config`.
+
+>>> audmodel.config.CACHE_ROOT
+'~/audmodel'
+
+>>> audmodel.config.REPOSITORIES
+[Repository('models-local', 'https://artifactory.audeering.com/artifactory', 'artifactory'), Repository('audmodel-internal', 's3.dualstack.eu-north-1.amazonaws.com', 's3')]
+
+>>> audmodel.config.CACHE_ROOT = "/user/cache"
+>>> audmodel.config.CACHE_ROOT
+'/user/cache'
+
+The cache folder
+can also be overwritten
+with the ``AUDMODEL_CACHE_ROOT`` environment variable.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@
     
     installation
     authentication
+    configuration
     usage
 
 .. Warning: the usage of genindex is a hack to get a TOC entry, see

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,10 @@ convention = 'google'
 [tool.setuptools.packages.find]
 include = ['audmodel*']
 
+# Ship the default configuration file with the package
+[tool.setuptools.package-data]
+audmodel = ['core/etc/*']
+
 # ----- setuptools_scm ----------------------------------------------------
 #
 # Use setuptools_scm to get version from git

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import yaml
 
@@ -61,7 +63,7 @@ def test_config_file(tmpdir):
         cf.write("repositories:\n")
     error_msg = (
         "You cannot specify an empty 'repositories:' section "
-        f"in the configuration file '{config_file}'."
+        f"in the configuration file '{re.escape(config_file)}'."
     )
     with pytest.raises(ValueError, match=error_msg):
         audmodel.core.config.load_configuration_file(config_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,7 +61,7 @@ def test_config_file(tmpdir):
         cf.write("repositories:\n")
     error_msg = (
         "You cannot specify an empty 'repositories:' section "
-        f"in the configuration file '{audmodel.core.define.USER_CONFIG_FILE}'."
+        f"in the configuration file '{config_file}'."
     )
     with pytest.raises(ValueError, match=error_msg):
         audmodel.core.config.load_configuration_file(config_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,132 @@
+import pytest
+import yaml
+
+import audeer
+
+import audmodel
+
+
+@pytest.fixture()
+def user_config_file(tmpdir):
+    """Provide a user config file.
+
+    The config file at ``.config/audmodel.yaml``
+    sets ``cache_root`` to ``~/user``.
+
+    Args:
+        tmpdir: tmpdir fixture.
+            The tmpdir is used as the home folder
+            for storing the user config file
+
+    """
+    home = audeer.mkdir(tmpdir)
+    current_user_config_file = audmodel.core.define.USER_CONFIG_FILE
+    audmodel.core.config.USER_CONFIG_FILE = audeer.path(
+        home, ".config", "audmodel.yaml"
+    )
+    audeer.mkdir(home, ".config")
+    with open(audeer.path(home, ".config", "audmodel.yaml"), "w") as fp:
+        fp.write("cache_root: ~/user\n")
+
+    yield
+
+    audmodel.core.config.USER_CONFIG_FILE = current_user_config_file
+
+
+def test_config_file(tmpdir):
+    root = audeer.mkdir(tmpdir)
+
+    config_file = audeer.path(root, "audmodel.yaml")
+
+    # Try loading non-existing file
+    config = audmodel.core.config.load_configuration_file(config_file)
+    assert config == {}
+
+    # Add a custom cache entry
+    # and check if combining with global config works
+    with open(config_file, "w") as cf:
+        cf.write("cache_root: ~/user\n")
+
+    config = audmodel.core.config.load_configuration_file(config_file)
+    assert config == {"cache_root": "~/user"}
+
+    global_config = audmodel.core.config.load_configuration_file(
+        audmodel.core.config.global_config_file
+    )
+    global_config.update(config)
+    assert global_config["cache_root"] == "~/user"
+
+    # Fail for empty repositories entry
+    with open(config_file, "w") as cf:
+        cf.write("repositories:\n")
+    error_msg = (
+        "You cannot specify an empty 'repositories:' section "
+        f"in the configuration file '{audmodel.core.define.USER_CONFIG_FILE}'."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        audmodel.core.config.load_configuration_file(config_file)
+
+    # Fail for missing repository entries
+    with open(config_file, "w") as cf:
+        cf.write("repositories:\n")
+        cf.write("  - host: some-host\n")
+        cf.write("    backend: some-backend\n")
+    error_msg = "Your repository is missing a 'name' entry"
+    with pytest.raises(ValueError, match=error_msg):
+        audmodel.core.config.load_configuration_file(config_file)
+
+    with open(config_file, "w") as cf:
+        cf.write("repositories:\n")
+        cf.write("  - name: my-repo\n")
+    error_msg = "Your repository is missing a 'host' entry."
+    with pytest.raises(ValueError, match=error_msg):
+        audmodel.core.config.load_configuration_file(config_file)
+
+    with open(config_file, "w") as cf:
+        cf.write("repositories:\n")
+        cf.write("  - name: my-repo\n")
+        cf.write("    host: some-host\n")
+    error_msg = "Your repository is missing a 'backend' entry"
+    with pytest.raises(ValueError, match=error_msg):
+        audmodel.core.config.load_configuration_file(config_file)
+
+    # Load custom repository
+    with open(config_file, "w") as cf:
+        cf.write("repositories:\n")
+        cf.write("  - name: my-repo\n")
+        cf.write("    host: some-host\n")
+        cf.write("    backend: some-backend\n")
+    config = audmodel.core.config.load_configuration_file(config_file)
+    assert config == {
+        "repositories": [
+            {
+                "name": "my-repo",
+                "host": "some-host",
+                "backend": "some-backend",
+            },
+        ]
+    }
+
+
+def test_user_config_file(user_config_file):
+    """Test that user config overwrites the global config."""
+    config = audmodel.core.config.load_config()
+    assert config["cache_root"] == "~/user"
+    # Global repositories are still present
+    assert len(config["repositories"]) > 0
+
+
+def test_empty_config_file(tmp_path):
+    """Test loading an empty config file."""
+    empty_config = tmp_path / "empty.yaml"
+    empty_config.write_text("")
+    config = audmodel.core.config.load_configuration_file(empty_config)
+    assert config == {}
+
+
+def test_invalid_config_file(tmp_path):
+    """Test loading a broken config file."""
+    invalid_config = tmp_path / "invalid.yaml"
+    invalid_config.write_text("{invalid: yaml: content}")
+    with pytest.raises(yaml.YAMLError):
+        audmodel.core.config.load_configuration_file(invalid_config)


### PR DESCRIPTION
Mirroring the behavior from `audb` this adds support for a config file (`~/.config/audmodel.yaml`) to set the default cache folder and repositories.

The main motivation for these changes are:

* Make it easier to setup a shared cache on a compute server (no longer requires to export env variables)
* Prepare `audmodel` to no longer ship with our default internal repositories, but just with one open repo (like we do it in `audb`), see https://github.com/audeering/audmodel/issues/48

<img width="719" height="670" alt="image" src="https://github.com/user-attachments/assets/03f1e0c0-6412-44db-92ed-55da75e58315" />

