### PR TITLE
Require repository in audmodel.publish()

### DIFF
--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -596,7 +596,10 @@ def publish(
     subgroup = subgroup or ""
 
     if repository is None:
-        raise ValueError("You have to provide a repository, see audmodel.Repository")
+        raise ValueError(
+            "You have to provide a repository, "
+            "see audmodel.config.REPOSITORIES for an example."
+        )
 
     if subgroup == define.UID_FOLDER:
         raise ValueError(f"It is not allowed to set subgroup to '{define.UID_FOLDER}'.")

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -596,7 +596,7 @@ def publish(
     subgroup = subgroup or ""
 
     if repository is None:
-        raise ValueError("You have to provide a repository.")
+        raise ValueError("You have to provide a repository, see audmodel.Repository")
 
     if subgroup == define.UID_FOLDER:
         raise ValueError(f"It is not allowed to set subgroup to '{define.UID_FOLDER}'.")

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -431,11 +431,11 @@ def publish(
     params: dict[str, object],
     version: str,
     *,
+    repository: Repository,
     alias: str | None = None,
     author: str | None = None,
     date: datetime.date | None = None,
     meta: dict[str, object] | None = None,
-    repository: Repository | None = None,
     subgroup: str | None = None,
     tmp_root: str | None = None,
     verbose: bool = False,
@@ -504,13 +504,13 @@ def publish(
         name: model name
         params: dictionary with parameters
         version: version string
+        repository: repository where the model will be published
         alias: optional alias name for the model.
             If provided, the model can be accessed using this alias
             in addition to its UID
         author: author name(s), defaults to user name
         date: date, defaults to current timestamp
         meta: dictionary with meta information
-        repository: repository where the model will be published
         subgroup: subgroup under which
             the model is stored on backend.
             ``.`` are replaced by ``/``

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -510,8 +510,7 @@ def publish(
         author: author name(s), defaults to user name
         date: date, defaults to current timestamp
         meta: dictionary with meta information
-        repository: repository where the model will be published,
-            defaults to ``config.REPOSITORIES[0]``
+        repository: repository where the model will be published
         subgroup: subgroup under which
             the model is stored on backend.
             ``.`` are replaced by ``/``
@@ -530,6 +529,7 @@ def publish(
         unique model ID
 
     Raises:
+        ValueError: if ``repository`` is ``None``
         audbackend.BackendError: if connection to repository on backend
             cannot be established
         RuntimeError: if a model with same UID exists already
@@ -596,7 +596,7 @@ def publish(
     subgroup = subgroup or ""
 
     if repository is None:
-        repository = config.REPOSITORIES[0]
+        raise ValueError("You have to provide a repository.")
 
     if subgroup == define.UID_FOLDER:
         raise ValueError(f"It is not allowed to set subgroup to '{define.UID_FOLDER}'.")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -139,19 +139,6 @@ SUBGROUP = f"{pytest.ID}.publish"
             audmodel.config.REPOSITORIES[0],
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        # missing repository
-        pytest.param(
-            pytest.MODEL_ROOT,
-            pytest.NAME,
-            pytest.PARAMS,
-            "1.0.0",
-            pytest.AUTHOR,
-            pytest.DATE,
-            pytest.META["1.0.0"],
-            SUBGROUP,
-            None,
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
     ),
 )
 def test_publish(root, name, subgroup, params, author, date, meta, version, repository):
@@ -294,3 +281,16 @@ def test_publish_tmp_root(tmp_path):
     # but the folder we created stays around
     assert os.path.isdir(tmp_root)
     assert audeer.list_file_names(tmp_root) == []
+
+
+def test_publish_missing_repository_raises():
+    """Test error message if repository is None."""
+    error_msg = "You have to provide a repository, see audmodel.Repository"
+    with pytest.raises(ValueError, match=error_msg):
+        audmodel.publish(
+            pytest.MODEL_ROOT,
+            pytest.NAME,
+            {},
+            "1.0.0",
+            repository=None,
+        )

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -285,7 +285,10 @@ def test_publish_tmp_root(tmp_path):
 
 def test_publish_missing_repository_raises():
     """Test error message if repository is None."""
-    error_msg = "You have to provide a repository, see audmodel.Repository"
+    error_msg = (
+        "You have to provide a repository, "
+        "see audmodel.config.REPOSITORIES for an example."
+    )
     with pytest.raises(ValueError, match=error_msg):
         audmodel.publish(
             pytest.MODEL_ROOT,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -26,7 +26,7 @@ SUBGROUP = f"{pytest.ID}.publish"
             pytest.DATE,
             pytest.META["1.0.0"],
             SUBGROUP,
-            None,
+            audmodel.config.REPOSITORIES[0],
         ),
         # different name
         pytest.param(
@@ -137,6 +137,19 @@ SUBGROUP = f"{pytest.ID}.publish"
             pytest.META["1.0.0"],
             "_uid",
             audmodel.config.REPOSITORIES[0],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        # missing repository
+        pytest.param(
+            pytest.MODEL_ROOT,
+            pytest.NAME,
+            pytest.PARAMS,
+            "1.0.0",
+            pytest.AUTHOR,
+            pytest.DATE,
+            pytest.META["1.0.0"],
+            SUBGROUP,
+            None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
     ),
@@ -272,6 +285,7 @@ def test_publish_tmp_root(tmp_path):
         date=pytest.DATE,
         subgroup=f"{SUBGROUP}.tmp_root",
         tmp_root=tmp_root,
+        repository=pytest.REPOSITORIES[0],
     )
 
     assert audmodel.exists(uid)


### PR DESCRIPTION
Change the default of the `repository` argument of `audmodel.publish()` from `None` to not given and require the user to provide it. As `None` was an allowed value before, we check for it and raise a `ValueError` if given.

We want the user to always have to select a repository as we want to limit the default repository to `audmodel-public`, in which we will only rarely publish a model.

<img width="723" height="65" alt="image" src="https://github.com/user-attachments/assets/db878e0d-83fd-473c-8f57-12b2934ed4d4" />
