### PR TITLE
Make audmodel-public default repo

### DIFF
--- a/audmodel/core/config.py
+++ b/audmodel/core/config.py
@@ -102,7 +102,7 @@ class config:
     containing the following attributes:
 
     * :attr:`audmodel.Repository.name`: repository name,
-      e.g. ``"models-local"``
+      e.g. ``"audmodel-public"``
     * :attr:`audmodel.Repository.backend`: backend name,
       e.g. ``"s3"``
     * :attr:`audmodel.Repository.host`: host name,

--- a/audmodel/core/etc/audmodel.yaml
+++ b/audmodel/core/etc/audmodel.yaml
@@ -1,8 +1,5 @@
 cache_root: ~/audmodel
 repositories:
-  - name: models-local
-    backend: artifactory
-    host: https://artifactory.audeering.com/artifactory
-  - name: audmodel-internal
-    backend: s3
+  - name: audmodel-public
     host: s3.dualstack.eu-north-1.amazonaws.com
+    backend: s3

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -4,27 +4,11 @@ Authentication
 To download or publish a model,
 a user has to authenticate.
 
-Credentials for the ``models-local`` repository
-on Artifactory
-are stored in ``~/.artifactory_python.cfg``:
+Credentials for repositories on S3
+are stored in ``~/.config/audbackend/minio.cfg``.
 
-.. code-block:: cfg
-
-    [artifactory.audeering.com/artifactory]
-    username = MY_USERNAME
-    password = MY_API_KEY
-
-Alternatively,
-they can export them as environment variables:
-
-.. code-block:: bash
-
-    export ARTIFACTORY_USERNAME="MY_USERNAME"
-    export ARTIFACTORY_API_KEY="MY_API_KEY"
-
-Credentials for the ``audmodel-internal`` repository
-on S3
-are stored in ``~/.config/audbackend/minio.cfg``:
+E.g. for write access to ``audmodel-public``,
+you need to add
 
 .. code-block:: cfg
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,7 +20,7 @@ using :class:`audmodel.config`.
 '~/audmodel'
 
 >>> audmodel.config.REPOSITORIES
-[Repository('models-local', 'https://artifactory.audeering.com/artifactory', 'artifactory'), Repository('audmodel-internal', 's3.dualstack.eu-north-1.amazonaws.com', 's3')]
+[Repository('audmodel-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3')]
 
 >>> audmodel.config.CACHE_ROOT = "/user/cache"
 >>> audmodel.config.CACHE_ROOT


### PR DESCRIPTION
Sets `audmodel-public` as the only default repository with the source code of `audmodel`.

<img width="727" height="252" alt="image" src="https://github.com/user-attachments/assets/856e303c-dc28-4110-83b2-f9ccc347a71a" />
