### PR TITLE
Remove support for artifactory backends

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,13 +89,7 @@ You can run tests with pytest_::
 
     uv run pytest
 
-To run the tests on the Gitlab CI server,
-contributors have to make sure
-they have an existing ``artifactory-tokenizer`` repository
-as described in the `Artifactory tokenizer documentation`_.
-
 .. _pytest: https://pytest.org/
-.. _Artifactory tokenizer documentation: https://gitlab.audeering.com/devops/artifactory/tree/master/token
 
 
 Creating a New Release

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -1136,15 +1136,6 @@ def url(
     # Check for underlying backend of backend interface
     if isinstance(backend_interface.backend, audbackend.backend.FileSystem):
         path = backend_interface.sep.join([backend_interface.backend._root, path])
-    elif isinstance(
-        backend_interface.backend, audbackend.backend.Artifactory
-    ):  # pragma: nocover
-        # The tests should work locally,
-        # so we don't test using a repository on Artifactory.
-        # I tested the following line,
-        # by manually calling
-        # audmodel.url("90398682-2.0.0")
-        path = str(backend_interface.backend.path(path))
     return path
 
 

--- a/audmodel/core/repository.py
+++ b/audmodel/core/repository.py
@@ -1,5 +1,3 @@
-import sys
-
 import audbackend
 
 import audmodel.core.define as define
@@ -35,16 +33,11 @@ class Repository:
         "s3": audbackend.backend.Minio,
     }
 
-    if hasattr(audbackend.backend, "Artifactory"):
-        _backends["artifactory"] = audbackend.backend.Artifactory  # pragma: no cover
-
     backend_registry = _backends
     r"""Backend registry.
 
     Holds mapping between registered backend names,
     and their corresponding backend classes.
-    The ``"artifactory"`` backend is currently not available
-    under Python >=3.13.
 
     """
 
@@ -94,14 +87,9 @@ class Repository:
             interface to repository
 
         Raises:
-            ValueError: if an artifactory backend is requested in Python>=3.13
             ValueError: if a non-supported backend is requested
 
         """
-        if sys.version_info >= (3, 13) and self.backend == "artifactory":
-            raise ValueError(  # pragma: no cover
-                "The 'artifactory' backend is not supported in Python>=3.13"
-            )
         if self.backend not in self.backend_registry:
             raise ValueError(f"'{self.backend}' is not a registered backend")
         backend_class = self.backend_registry[self.backend]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -120,7 +120,7 @@ Let's define the arguments for our example model:
     }
     subgroup = "emotion.cnn"
 
-Per default :mod:`audmodel` uses repositories on S3.
+By default :mod:`audmodel` uses repositories on S3.
 For this example
 we create a local temporary repository
 in which the model is stored.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -120,8 +120,7 @@ Let's define the arguments for our example model:
     }
     subgroup = "emotion.cnn"
 
-Per default :mod:`audmodel` uses repositories
-on Artifactory and S3.
+Per default :mod:`audmodel` uses repositories on S3.
 For this example
 we create a local temporary repository
 in which the model is stored.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ license-files = ['LICENSE']
 keywords = [
     'machine learning',
     'model',
-    'Artifactory',
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,16 +1,8 @@
-import sys
-
 import pytest
 
 import audbackend
 
 import audmodel
-
-
-if hasattr(audbackend.backend, "Artifactory"):
-    artifactory_backend = audbackend.backend.Artifactory
-else:
-    artifactory_backend = None
 
 
 @pytest.mark.parametrize(
@@ -78,17 +70,6 @@ def test_repository_repr(backend, host, repo, expected):
             audbackend.backend.FileSystem,
             audbackend.interface.Versioned,
         ),
-        pytest.param(
-            "artifactory",
-            "host",
-            "repo",
-            artifactory_backend,
-            audbackend.interface.Maven,
-            marks=pytest.mark.skipif(
-                sys.version_info >= (3, 13),
-                reason="No artifactory backend support in Python>=3.13",
-            ),
-        ),
     ],
 )
 def test_repository_create_backend_interface(
@@ -124,17 +105,6 @@ def test_repository_create_backend_interface(
             "repo",
             "'custom' is not a registered backend",
             ValueError,
-        ),
-        pytest.param(
-            "artifactory",
-            "host",
-            "repo",
-            "The 'artifactory' backend is not supported in Python>=3.13",
-            ValueError,
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 13),
-                reason="Should only fail for Python>=3.13",
-            ),
         ),
     ],
 )


### PR DESCRIPTION
As we no longer have repositories on Artifactory, and we are going to remove Artifactory support with the next `audbackend` release, we remove already all Artifactory related code here.