### PR TITLE
Fix link to Github in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,10 @@ html_theme = "sphinx_audeering_theme"
 html_theme_options = {
     "display_version": True,
     "logo_only": False,
+    "footer_links": False,
+}
+html_context = {
+    "display_github": True,
 }
 html_title = title
 html_static_path = ["_static"]


### PR DESCRIPTION
Closes #55 

Fixes the link to Github and removes the footer links to our internal documentation.