### PR TITLE
Depend on audbackend[all]>=3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] >=2.2.3',
+    'audbackend[all] >=3.0.0',
     'filelock',
     'oyaml',
 ]


### PR DESCRIPTION
Depend on audbackend[all]>=3.0.0 to ensure we can use the new host specific environment variables from audbackend.backend.Minio.