### PR TITLE
Use sybil for doctests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,6 @@ exclude_patterns = [
 templates_path = ["_templates"]
 pygments_style = None
 extensions = [
-    "jupyter_sphinx",  # executing code blocks
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",  # support for Google-style docstrings
     "sphinx.ext.autosummary",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,15 +16,21 @@ they can be accessed
 or changed
 using :class:`audmodel.config`.
 
->>> audmodel.config.CACHE_ROOT
-'~/audmodel'
+.. code-block:: pycon
 
->>> audmodel.config.REPOSITORIES
-[Repository('audmodel-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3')]
+    >>> audmodel.config.CACHE_ROOT
+    '~/audmodel'
 
->>> audmodel.config.CACHE_ROOT = "/user/cache"
->>> audmodel.config.CACHE_ROOT
-'/user/cache'
+.. code-block:: pycon
+
+    >>> audmodel.config.REPOSITORIES
+    [Repository('audmodel-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3')]
+
+.. code-block:: pycon
+
+    >>> audmodel.config.CACHE_ROOT = "/user/cache"
+    >>> audmodel.config.CACHE_ROOT
+    '/user/cache'
 
 The cache folder
 can also be overridden

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,100 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+import os
+
+import pytest
+import sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import SkipParser
+
+import audmodel
+from audmodel.core.config import global_config_file
+from audmodel.core.config import load_configuration_file
+
+
+def imports(namespace):
+    """Make :mod:`audmodel` available inside the documentation namespace."""
+    namespace["audmodel"] = audmodel
+
+
+@pytest.fixture(scope="module")
+def run_in_tmpdir(tmpdir_factory):
+    """Execute the whole documentation file inside a persistent tmpdir."""
+    tmpdir = tmpdir_factory.mktemp("tmp")
+    current_dir = os.getcwd()
+    os.chdir(tmpdir)
+
+    yield
+
+    os.chdir(current_dir)
+
+
+@pytest.fixture(scope="module")
+def reset_config():
+    """Restore config values that are changed inside the documentation."""
+    cache_root = audmodel.config.CACHE_ROOT
+    repositories = audmodel.config.REPOSITORIES
+    # Other tests set ``AUDMODEL_CACHE_ROOT``,
+    # which would take precedence over ``config.CACHE_ROOT``.
+    # Remove it here, so the cache folder used in the documentation
+    # is the one configured via ``config.CACHE_ROOT``.
+    env_cache_root = os.environ.pop("AUDMODEL_CACHE_ROOT", None)
+
+    yield
+
+    audmodel.config.CACHE_ROOT = cache_root
+    audmodel.config.REPOSITORIES = repositories
+    if env_cache_root is not None:
+        os.environ["AUDMODEL_CACHE_ROOT"] = env_cache_root
+
+
+@pytest.fixture(scope="module")
+def default_configuration():
+    """Provide the default configuration values.
+
+    Other tests change the values of :class:`audmodel.config`,
+    so we restore the default values from the config file here,
+    and reset them afterwards.
+
+    """
+    cache_root = audmodel.config.CACHE_ROOT
+    repositories = audmodel.config.REPOSITORIES
+
+    default = load_configuration_file(global_config_file)
+    audmodel.config.CACHE_ROOT = default["cache_root"]
+    audmodel.config.REPOSITORIES = [
+        audmodel.Repository(repo["name"], repo["host"], repo["backend"])
+        for repo in default["repositories"]
+    ]
+
+    yield
+
+    audmodel.config.CACHE_ROOT = cache_root
+    audmodel.config.REPOSITORIES = repositories
+
+
+# Collect doctests and code blocks from the documentation.
+#
+# We use several ``sybil.Sybil`` instances
+# to pass different fixtures to different files.
+parsers = [
+    DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE),
+    PythonCodeBlockParser(),
+    SkipParser(),
+]
+pytest_collect_file = sybil.sybil.SybilCollection(
+    (
+        sybil.Sybil(
+            parsers=parsers,
+            filenames=["usage.rst"],
+            fixtures=["run_in_tmpdir", "reset_config"],
+        ),
+        sybil.Sybil(
+            parsers=parsers,
+            filenames=["configuration.rst"],
+            fixtures=["default_configuration"],
+            setup=imports,
+        ),
+    )
+).pytest()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -79,7 +79,7 @@ def default_configuration():
 # We use several ``sybil.Sybil`` instances
 # to pass different fixtures to different files.
 parsers = [
-    DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE),
+    DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
     PythonCodeBlockParser(),
     SkipParser(),
 ]

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 import sybil
+from sybil.parsers.rest import CaptureParser
 from sybil.parsers.rest import DocTestParser
 from sybil.parsers.rest import PythonCodeBlockParser
 from sybil.parsers.rest import SkipParser
@@ -79,6 +80,7 @@ def default_configuration():
 # We use several ``sybil.Sybil`` instances
 # to pass different fixtures to different files.
 parsers = [
+    CaptureParser(),
     DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
     PythonCodeBlockParser(),
     SkipParser(),

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -34,7 +34,7 @@ def run_in_tmpdir(tmpdir_factory):
 def reset_config():
     """Restore config values that are changed inside the documentation."""
     cache_root = audmodel.config.CACHE_ROOT
-    repositories = audmodel.config.REPOSITORIES
+    repositories = list(audmodel.config.REPOSITORIES)
     # Other tests set ``AUDMODEL_CACHE_ROOT``,
     # which would take precedence over ``config.CACHE_ROOT``.
     # Remove it here, so the cache folder used in the documentation

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,6 +3,8 @@ Usage
 
 .. invisible-code-block: python
 
+    import contextlib
+    import io
     import os
 
     import audeer
@@ -18,6 +20,29 @@ Usage
             with open(path, "w"):
                 pass
         return root
+
+
+    def show_model(path):
+        path = audeer.safe_path(path)
+        for root, dirs, files in os.walk(path):
+            dirs.sort()
+            files.sort()
+            level = root.replace(path, "").count(os.sep)
+            indent = " " * 4 * (level)
+            print("{}{}/".format(indent, os.path.basename(root)))
+            subindent = " " * 4 * (level + 1)
+            for f in files:
+                print("{}{}".format(subindent, f))
+
+
+    def model_tree(path):
+        # Capture the output of ``show_model()`` as a string,
+        # so it can be compared against the folder tree
+        # shown in the documentation.
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            show_model(path)
+        return buffer.getvalue().strip() + "\n"
 
 
     cache_dir = audeer.mkdir("./tmp/cache")
@@ -61,6 +86,12 @@ consisting of the following files:
         readme.txt
         log/
             eval.yaml
+
+.. -> expected_tree
+
+.. invisible-code-block: python
+
+    assert model_tree(root_v1) == expected_tree
 
 Before we can publish a model,
 we have to define several arguments:
@@ -200,6 +231,12 @@ we will then have the following structure.
         log/
             eval.yaml
 
+.. -> expected_tree
+
+.. invisible-code-block: python
+
+    assert model_tree(model_root) == expected_tree
+
 
 Model alias
 -----------
@@ -279,6 +316,12 @@ this time called ``root_v2``:
         readme.txt
         log/
             eval.yaml
+
+.. -> expected_tree
+
+.. invisible-code-block: python
+
+    assert model_tree(root_v2) == expected_tree
 
 As this model has the same parameters, name, and subgroup
 as our previous model,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,13 +1,9 @@
 Usage
 =====
 
-.. jupyter-execute::
-    :stderr:
-    :hide-output:
-    :hide-code:
+.. invisible-code-block: python
 
     import os
-    import glob
 
     import audeer
     import audmodel
@@ -24,20 +20,17 @@ Usage
         return root
 
 
-    def show_model(path):
-        path = audeer.safe_path(path)
-        for root, dirs, files in os.walk(path):
-            level = root.replace(path, "").count(os.sep)
-            indent = " " * 4 * (level)
-            print("{}{}/".format(indent, os.path.basename(root)))
-            subindent = " " * 4 * (level + 1)
-            for f in files:
-                print("{}{}".format(subindent, f))
-
-
     cache_dir = audeer.mkdir("./tmp/cache")
     model_dir = audeer.mkdir("./tmp/models")
     audmodel.config.CACHE_ROOT = cache_dir
+
+    files = [
+        "model.yaml",
+        "model.onnx",
+        "readme.txt",
+        "log/eval.yaml",
+    ]
+    root_v1 = create_model("root_v1", files, model_dir)
 
 
 Introduction
@@ -57,20 +50,17 @@ and **metadata**
 Publish a model
 ---------------
 
-Let’s assume we have a model folder ``root_v1``,
+Let's assume we have a model folder ``root_v1``,
 consisting of the following files:
 
-.. jupyter-execute::
-    :hide-code:
+.. code-block:: text
 
-    files = [
-        "model.yaml",
-        "model.onnx",
-        "readme.txt",
-        "log/eval.yaml",
-    ]
-    root_v1 = create_model("root_v1", files, model_dir)
-    show_model(root_v1)
+    root_v1/
+        model.onnx
+        model.yaml
+        readme.txt
+        log/
+            eval.yaml
 
 Before we can publish a model,
 we have to define several arguments:
@@ -88,7 +78,7 @@ have a look at the discussion in the API documentation of
 
 Let's define the arguments for our example model:
 
-.. jupyter-execute::
+.. code-block:: python
 
     name = "onnx"
     params = {
@@ -98,7 +88,7 @@ Let's define the arguments for our example model:
         "sampling_rate": 16000,
     }
     version = "1.0.0"
-    author="sphinx"
+    author = "sphinx"
     meta = {
         "model": {
             "cnn10": {
@@ -125,7 +115,7 @@ For this example
 we create a local temporary repository
 in which the model is stored.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audeer
     import audmodel
@@ -136,23 +126,22 @@ in which the model is stored.
     repository = audmodel.Repository(repo, host, "file-system")
     audmodel.config.REPOSITORIES = [repository]
 
-
-
 Now we can publish the model with
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    uid = audmodel.publish(
-        root_v1,
-        name,
-        params,
-        version,
-        author=author,
-        meta=meta,
-        subgroup=subgroup,
-        repository=repository,
-    )
-    uid
+    >>> uid = audmodel.publish(
+    ...     root_v1,
+    ...     name,
+    ...     params,
+    ...     version,
+    ...     author=author,
+    ...     meta=meta,
+    ...     subgroup=subgroup,
+    ...     repository=repository,
+    ... )
+    >>> uid
+    '3e120e8d-1.0.0'
 
 The publishing process returns a unique model ID,
 that can be used to access the model.
@@ -165,41 +154,51 @@ Load a model
 
 With the model ID we can check if a model exists:
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.exists(uid)
+    >>> audmodel.exists(uid)
+    True
 
 Or get its name,
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.name(uid)
+    >>> audmodel.name(uid)
+    'onnx'
 
 parameters,
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.parameters(uid)
+    >>> audmodel.parameters(uid)
+    {'model': 'cnn10', 'data': ['emodb', 'msppodcast'], 'feature': 'melspec', 'sampling_rate': 16000}
 
 and meta fields.
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.meta(uid)
+    >>> audmodel.meta(uid)
+    {'model': {'cnn10': {'learning-rate': 0.01, 'optimizer': 'adam'}},
+     'data': {'emodb': {'version': '1.1.1'}, 'msppodcast': {'version': '2.6.0'}},
+     'feature': {'melspec': {'win_dur': '32ms', 'hop_dur': '10ms', 'mel_bins': 64}}}
 
 To actually load the actual model, we do:
 
-.. jupyter-execute::
+.. code-block:: python
 
     model_root = audmodel.load(uid)
 
 Inside the :file:`model_root` folder
 we will then have the following structure.
 
-.. jupyter-execute::
-    :hide-code:
+.. code-block:: text
 
-    show_model(model_root)
+    1.0.0/
+        model.onnx
+        model.yaml
+        readme.txt
+        log/
+            eval.yaml
 
 
 Model alias
@@ -211,20 +210,21 @@ to refer to a model.
 An alias can already be selected during publication,
 or it can be set afterwards with
 
-.. jupyter-execute::
+.. code-block:: python
 
     audmodel.set_alias("emotion-small", uid)
 
 We can inspect the corresponding model ID with
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.resolve_alias("emotion-small")
+    >>> audmodel.resolve_alias("emotion-small")
+    '3e120e8d-1.0.0'
 
 and use the alias instead of the model ID
 to access the model, e.g.
 
-.. jupyter-execute::
+.. code-block:: python
 
     model_root = audmodel.load("emotion-small")
 
@@ -233,15 +233,16 @@ requires access to the backend on which the model is stored.
 
 We can add more than one alias for a model
 
-.. jupyter-execute::
+.. code-block:: python
 
     audmodel.set_alias("emotion-production", uid)
 
 and can inspect existing aliases for a model ID with
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.aliases(uid)
+    >>> audmodel.aliases(uid)
+    ['emotion-production', 'emotion-small']
 
 We can update to which model ID an alias is pointing
 by running :func:`audmodel.set_alias` again,
@@ -259,67 +260,79 @@ As an example,
 let's assume we switch to less Mel frequency bins
 in the feature extractor.
 
-.. jupyter-execute::
+.. code-block:: python
 
     meta["feature"]["melspec"]["mel_bins"] = 32
+
+.. invisible-code-block: python
+
+    root_v2 = create_model("root_v2", files, model_dir)
 
 Let's again assume we have a model folder,
 this time called ``root_v2``:
 
-.. jupyter-execute::
-    :hide-code:
+.. code-block:: text
 
-    root_v2 = create_model("root_v2", files, model_dir)
-    show_model(root_v2)
+    root_v2/
+        model.onnx
+        model.yaml
+        readme.txt
+        log/
+            eval.yaml
 
 As this model has the same parameters, name, and subgroup
 as our previous model,
 we choose a new version number,
 and publish it with:
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    uid_v1 = uid
-    uid = audmodel.publish(
-        root_v2,
-        name,
-        params,
-        "2.0.0",
-        meta=meta,
-        subgroup=subgroup,
-        repository=repository,
-    )
-    uid
+    >>> uid_v1 = uid
+    >>> uid = audmodel.publish(
+    ...     root_v2,
+    ...     name,
+    ...     params,
+    ...     "2.0.0",
+    ...     meta=meta,
+    ...     subgroup=subgroup,
+    ...     repository=repository,
+    ... )
+    >>> uid
+    '3e120e8d-2.0.0'
 
 Now we have published two versions of the model:
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.versions(uid)
+    >>> audmodel.versions(uid)
+    ['1.0.0', '2.0.0']
 
 To find the latest version we can do:
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.latest_version(uid)
+    >>> audmodel.latest_version(uid)
+    '2.0.0'
 
 We can update our existing model aliases
 to point to the newest version.
 
-.. jupyter-execute::
+.. code-block:: python
 
     audmodel.set_alias("emotion-small", uid)
     audmodel.set_alias("emotion-production", uid)
 
 Now, all model aliases are only pointing to the new version:
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.aliases(uid_v1)
+    >>> audmodel.aliases(uid_v1)
+    []
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    audmodel.aliases(uid)
+    >>> audmodel.aliases(uid)
+    ['emotion-production', 'emotion-small']
 
 
 Update metadata
@@ -335,24 +348,26 @@ that holds new / altered information.
 As the following example shows
 this even works with nested fields.
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    meta = {
-        "model": {
-            "cnn10": {"layers": 10},
-        },
-    }
-    audmodel.update_meta(uid, meta)
-    audmodel.meta(uid)
+    >>> meta = {
+    ...     "model": {
+    ...         "cnn10": {"layers": 10},
+    ...     },
+    ... }
+    >>> audmodel.update_meta(uid, meta)
+    {'model': {'cnn10': {'learning-rate': 0.01, 'optimizer': 'adam', 'layers': 10}},
+     'data': {'emodb': {'version': '1.1.1'}, 'msppodcast': {'version': '2.6.0'}},
+     'feature': {'melspec': {'win_dur': '32ms', 'hop_dur': '10ms', 'mel_bins': 32}}}
 
 Alternatively,
 we can replace the metadata.
 
-.. jupyter-execute::
+.. code-block:: pycon
 
-    meta = {"new": "meta"}
-    audmodel.update_meta(uid, meta, replace=True)
-    audmodel.meta(uid)
+    >>> meta = {"new": "meta"}
+    >>> audmodel.update_meta(uid, meta, replace=True)
+    {'new': 'meta'}
 
 
 Cache folder
@@ -361,14 +376,9 @@ Cache folder
 Models are unpacked to the model cache folder,
 which can be checked by:
 
-.. jupyter-execute::
+.. code-block:: python
 
     cache_root = audmodel.default_cache_root()
-    cache_root
-
-.. jupyter-execute::
-
-    audeer.list_dir_names(cache_root, basenames=True)
 
 We can change the location of the cache folder
 by setting an environment variable:
@@ -379,9 +389,11 @@ by setting an environment variable:
 
 Or by changing it inside :class:`audmodel.config`:
 
+.. skip: next
+
 .. code-block:: python
 
-    audmodel.config.CACHE_ROOT="/path/to/your/cache"
+    audmodel.config.CACHE_ROOT = "/path/to/your/cache"
 
 Or individually,
 by calling :func:`audmodel.load`
@@ -390,6 +402,11 @@ with a non empty ``cache_root`` argument.
 Within the model cache folder
 the model is placed in a unique sub-folder, namely
 ``<uid>/<version>``.
+
+.. code-block:: pycon
+
+    >>> audeer.list_dir_names(cache_root, basenames=True)
+    ['3e120e8d']
 
 
 Shared cache folder
@@ -404,9 +421,3 @@ in ``audb``'s documentation.
 when trying to access the same file.
 You can only use a shared cache on the same platform
 as the file lock mechanism is not cross-platform compatible.
-
-
-.. jupyter-execute::
-    :hide-code:
-
-    audeer.rmdir("./tmp")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ documentation = 'http://tools.pp.audeering.com/audmodel/'
 [dependency-groups]
 dev = [
     'audeer >=1.3.0',
-    'ipykernel',
-    'jupyter-sphinx >=0.3.1',
     'parse',
     'pytest',
     'pytest-cov',
@@ -57,6 +55,7 @@ dev = [
     'sphinx-audeering-theme >=1.2.1',
     'sphinx-autodoc-typehints',
     'sphinx-copybutton',
+    'sybil >=6.1.0',
     'toml',
 ]
 
@@ -91,7 +90,6 @@ addopts = '''
     --cov-fail-under=100
     --cov-report xml
     --cov-report term-missing
-    --ignore=docs/
     --ignore=misc/
 '''
 


### PR DESCRIPTION
Use `sybil` instead of `jupyter-sphinx` for better separation of testing and building the documentation.