### PR TITLE
Add audmodel.repository()

### DIFF
--- a/audmodel/__init__.py
+++ b/audmodel/__init__.py
@@ -11,6 +11,7 @@ from audmodel.core.api import meta
 from audmodel.core.api import name
 from audmodel.core.api import parameters
 from audmodel.core.api import publish
+from audmodel.core.api import repository
 from audmodel.core.api import resolve_alias
 from audmodel.core.api import set_alias
 from audmodel.core.api import subgroup

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -752,7 +752,6 @@ def repository(
         RuntimeError: if model does not exist
 
     Examples:
-        >>> import audmodel
         >>> audmodel.repository("d4e9c65b-3.0.0").name
         'repo1'
 

--- a/audmodel/core/api.py
+++ b/audmodel/core/api.py
@@ -726,6 +726,60 @@ def publish(
     return uid
 
 
+def repository(
+    uid: str,
+    *,
+    cache_root: str | None = None,
+) -> Repository:
+    r"""Repository of a model.
+
+    Returns the repository
+    in which the model is stored,
+    by searching through
+    :attr:`audmodel.config.REPOSITORIES`.
+
+    Args:
+        uid: unique model ID (omit version for latest version) or alias
+        cache_root: cache folder where models and headers are stored.
+            If not set :meth:`audmodel.default_cache_root` is used
+
+    Returns:
+        repository that stores the model
+
+    Raises:
+        audbackend.BackendError: if connection to repository on backend
+            cannot be established
+        RuntimeError: if model does not exist
+
+    Examples:
+        >>> import audmodel
+        >>> audmodel.repository("d4e9c65b-3.0.0").name
+        'repo1'
+
+    """
+    cache_root = audeer.safe_path(cache_root or default_cache_root())
+    short_id, version = split_uid(uid, cache_root)
+
+    for repo in config.REPOSITORIES:
+        backend_interface = repo.create_backend_interface()
+        path = backend_interface.join(
+            "/",
+            define.UID_FOLDER,
+            f"{short_id}.{define.HEADER_EXT}",
+        )
+        with backend_interface.backend:
+            header_exists = backend_interface.exists(
+                path,
+                version,
+                suppress_backend_errors=True,
+            )
+        if header_exists:
+            return repo
+
+    # If no repository can be found, the requested model does not exist
+    raise_model_not_found_error(short_id, version)
+
+
 def resolve_alias(
     alias: str,
     *,

--- a/docs/api-src/audmodel.rst
+++ b/docs/api-src/audmodel.rst
@@ -22,6 +22,7 @@ audmodel
     parameters
     publish
     Repository
+    repository
     resolve_alias
     set_alias
     subgroup

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,6 +70,7 @@ def fixture_publish_model():
         audmodel.meta,
         audmodel.name,
         audmodel.parameters,
+        audmodel.repository,
         audmodel.subgroup,
         lambda uid: audmodel.update_meta(uid, {}),
         audmodel.url,
@@ -142,6 +143,9 @@ def test_bad_uid(uid, expected_error):
 
     with pytest.raises(RuntimeError, match=expected_error):
         audmodel.parameters(uid)
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        audmodel.repository(uid)
 
     with pytest.raises(RuntimeError, match=expected_error):
         audmodel.subgroup(uid)
@@ -261,6 +265,32 @@ def test_uid(name, params, version, subgroup, expected):
         subgroup=subgroup,
     )
     assert uid == expected
+
+
+def test_repository():
+    # Full UID
+    uid = audmodel.uid(
+        pytest.NAME,
+        pytest.PARAMS,
+        "1.0.0",
+        subgroup=SUBGROUP,
+    )
+    assert audmodel.repository(uid) == pytest.REPOSITORIES[0]
+
+    # Short ID resolves to latest version
+    short_id = audmodel.uid(
+        pytest.NAME,
+        pytest.PARAMS,
+        subgroup=SUBGROUP,
+    )
+    assert audmodel.repository(short_id) == pytest.REPOSITORIES[0]
+
+    # Non-existing version
+    with pytest.raises(
+        RuntimeError,
+        match=f"A model with ID '{short_id}-9.9.9' does not exist.",
+    ):
+        audmodel.repository(f"{short_id}-9.9.9")
 
 
 def test_update_meta():


### PR DESCRIPTION
As I was confronted a few times with the question in which repository a given model is published, I decided to add `audmodel.repository()` similar to `audb.repsoitory()` to return the repository for a given model.

<img width="715" height="687" alt="image" src="https://github.com/user-attachments/assets/4b7da4ba-1edb-47de-b2aa-2a985d8adf0a" />
